### PR TITLE
Add delegate multiinvoker support, pass default addresses where available

### DIFF
--- a/src/constants/vaults.ts
+++ b/src/constants/vaults.ts
@@ -41,7 +41,7 @@ export const ChainVaults: {
     bravo: getAddress('0x699e37DfCEe5c6E4c5D0bC1C2FFbC2afEC55f6FB'),
   },
   [arbitrumSepolia.id]: {
-    alpha: getAddress('0xB3820Ef7fF9cbd3f9FF9176C19464b3178fB2bC3'),
+    alpha: getAddress('0x1602A47BbFB5a3a59cA1788d35ee5e8e79AB84aF'),
   },
 
   [base.id]: {},

--- a/src/lib/contracts.ts
+++ b/src/lib/contracts.ts
@@ -156,16 +156,16 @@ export function getKeeperOracleContract(keeperOracleAddress: Address, publicClie
   })
 }
 
+/**
+ * Contracts module class
+ * @param config SDK configuration
+ * @param config.chainId {@link SupportedChainId}
+ * @param config.publicClient {@link PublicClient}
+ * @param config.signer {@link WalletClient}
+ *
+ * @returns Contracts module instance
+ */
 export class ContractsModule {
-  /**
-   * Contracts module class
-   * @param config SDK configuration
-   * @param config.chainId {@link SupportedChainId}
-   * @param config.publicClient {@link PublicClient}
-   * @param config.signer {@link WalletClient}
-   *
-   * @returns Contracts module instance
-   */
   private config: {
     chainId: SupportedChainId
     publicClient: PublicClient

--- a/src/lib/markets/chain.ts
+++ b/src/lib/markets/chain.ts
@@ -126,8 +126,8 @@ export type MarketSnapshots = NonNullable<Awaited<ReturnType<typeof fetchMarketS
 export async function fetchMarketSnapshots({
   publicClient,
   pythClient,
-  chainId = DefaultChain.id,
-  address = zeroAddress,
+  chainId,
+  address,
   marketOracles,
   onError,
   onSuccess,

--- a/src/lib/markets/index.ts
+++ b/src/lib/markets/index.ts
@@ -1,12 +1,12 @@
 import { EvmPriceServiceConnection } from '@perennial/pyth-evm-js'
 import { GraphQLClient } from 'graphql-request'
-import { Address, PublicClient, WalletClient } from 'viem'
+import { Address, PublicClient, WalletClient, zeroAddress } from 'viem'
 
 import { InterfaceFeeBps, SupportedChainId, chainIdToChainMap } from '../../constants'
-import { MarketsAccountCheckpointsQuery } from '../../types/gql/graphql'
-import { MarketOracles, MarketSnapshot, UserMarketSnapshot, fetchMarketOracles, fetchMarketSnapshots } from './chain'
+import { OptionalAddress } from '../../types/perennial'
+import { throwIfZeroAddress } from '../../utils/addressUtils'
+import { fetchMarketOracles, fetchMarketSnapshots } from './chain'
 import {
-  Markets,
   fetchActivePositionHistory,
   fetchActivePositionPnl,
   fetchHistoricalPositions,
@@ -18,17 +18,17 @@ import {
   fetchTradeHistory,
 } from './graph'
 import {
+  BuildCancelOrderTxArgs,
   BuildModifyPositionTxArgs,
   BuildPlaceOrderTxArgs,
   BuildSubmitVaaTxArgs,
-  CancelOrderDetails,
   buildCancelOrderTx,
   buildModifyPositionTx,
   buildPlaceOrderTx,
   buildSubmitVaaTx,
 } from './tx'
 
-type OmitBound<T> = Omit<T, 'chainId' | 'graphClient' | 'publicClient' | 'pythClient'>
+type OmitBound<T> = Omit<T, 'chainId' | 'graphClient' | 'publicClient' | 'pythClient' | 'address'>
 
 type MarketsModuleConfig = {
   chainId: SupportedChainId
@@ -37,23 +37,28 @@ type MarketsModuleConfig = {
   pythClient: EvmPriceServiceConnection
   walletClient?: WalletClient
   interfaceFeeBps?: InterfaceFeeBps
+  operatingFor?: Address
 }
+
+/**
+ * Markets module class
+ * @param config SDK configuration
+ * @param config.chainId {@link SupportedChainId}
+ * @param config.publicClient Public Client
+ * @param config.graphClient GraphQL Client
+ * @param config.pythClient Pyth Client
+ * @param config.walletClient Wallet Client
+ * @param config.interfaceFeeBps Interface Fee rates and recipient {@link InterfaceFeeBps}
+ * @param config.operatingFor If set, the module will read data and send multi-invoker transactions on behalf of this address.
+ * @returns Markets module instance
+ */
 export class MarketsModule {
-  /**
-   * Markets module class
-   * @param config SDK configuration
-   * @param config.chainId {@link SupportedChainId}
-   * @param config.publicClient Public Client
-   * @param config.graphClient GraphQL Client
-   * @param config.pythClient Pyth Client
-   * @param config.walletClient Wallet Client
-   * @param config.interfaceFeeBps Interface Fee rates and recipient {@link InterfaceFeeBps}
-   * @returns Markets module instance
-   */
   private config: MarketsModuleConfig
+  private defaultAddress: Address = zeroAddress
 
   constructor(config: MarketsModuleConfig) {
     this.config = config
+    this.defaultAddress = config.operatingFor ?? config.walletClient?.account?.address ?? this.defaultAddress
   }
 
   get read() {
@@ -67,83 +72,70 @@ export class MarketsModule {
       },
       /**
        * Fetches the {@link MarketSnapshots}
-       * @param address Wallet Address
+       * @param address Wallet Address [defaults to operatingFor or walletSigner address if set]
        * @param marketOracles {@link MarketOracles}
        * @param onError Error callback
        * @param onSuccess Success callback
        * @returns The {@link MarketSnapshots}.
        */
-      marketSnapshots: (args: {
-        address: Address
-        marketOracles?: MarketOracles
-        onError?: () => void
-        onSuccess?: () => void
-      }) => {
+      marketSnapshots: (args: OmitBound<Parameters<typeof fetchMarketSnapshots>[0]> & OptionalAddress = {}) => {
         return fetchMarketSnapshots({
           chainId: this.config.chainId,
           publicClient: this.config.publicClient,
           pythClient: this.config.pythClient,
+          address: this.defaultAddress,
           ...args,
         })
       },
       /**
        * Fetches position PnL for a given market and Address
-       * @param address Wallet Address
+       * @param address Wallet Address [defaults to operatingFor or walletSigner address if set]
        * @param market Market Address
        * @param userMarketSnapshot {@link UserMarketSnapshot}
        * @param marketSnapshot {@link MarketSnapshot}
        * @param includeClosedWithCollateral Include closed positions with collateral
        * @returns User's PnL for an active position.
        */
-      activePositionPnl: (args: {
-        market: Address
-        marketSnapshot: MarketSnapshot
-        userMarketSnapshot: UserMarketSnapshot
-        address: Address
-        includeClosedWithCollateral?: boolean
-      }) => {
+      activePositionPnl: (args: OmitBound<Parameters<typeof fetchActivePositionPnl>[0]> & OptionalAddress) => {
         return fetchActivePositionPnl({
           graphClient: this.config.graphClient,
+          address: this.defaultAddress,
           ...args,
         })
       },
       /**
        * Fetches active position history for a given address
-       * @param address Wallet Address
+       * @param address Wallet Address [defaults to operatingFor or walletSigner address if set]
        * @param market Market Address
        * @param pageParam Page number
        * @param pageSize Page size
        * @returns User's position history for an active position.
        */
-      activePositionHistory: (args: { market: Address; address: Address; pageParam: number; pageSize: number }) => {
+      activePositionHistory: (args: OmitBound<Parameters<typeof fetchActivePositionHistory>[0]> & OptionalAddress) => {
         return fetchActivePositionHistory({
           graphClient: this.config.graphClient,
+          address: this.defaultAddress,
           ...args,
         })
       },
       /**
        * Fetches the position history for a given address
-       * @param address Wallet Address
+       * @param address Wallet Address [defaults to operatingFor or walletSigner address if set]
        * @param markets List of {@link Markets} to fetch position history for
        * @param pageParam Page number
        * @param pageSize Page size
        * @returns User's position history.
        */
-      historicalPositions: (args: {
-        markets: Markets
-        address: Address
-        pageSize: number
-        pageParam?: { page: number; checkpoints?: MarketsAccountCheckpointsQuery }
-        maker?: boolean
-      }) => {
+      historicalPositions: (args: OmitBound<Parameters<typeof fetchHistoricalPositions>[0]> & OptionalAddress) => {
         return fetchHistoricalPositions({
           graphClient: this.config.graphClient,
+          address: this.defaultAddress,
           ...args,
         })
       },
       /**
        * Fetches the sub positions activity for a given position
-       * @param address Wallet Address
+       * @param address Wallet Address [defaults to operatingFor or walletSigner address if set]
        * @param market Market Address
        * @param startVersion BigInt - Start oracle version number
        * @param endVersion BigInt - End oracle version number
@@ -151,49 +143,39 @@ export class MarketsModule {
        * @param skip Number of entries to skip
        * @returns User's sub positions.
        */
-      subPositions: (args: {
-        address: Address
-        market: Address
-        startVersion: bigint
-        endVersion?: bigint
-        first: number
-        skip: number
-      }) => {
+      subPositions: (args: OmitBound<Parameters<typeof fetchSubPositions>[0]> & OptionalAddress) => {
         return fetchSubPositions({
           graphClient: this.config.graphClient,
+          address: this.defaultAddress,
           ...args,
         })
       },
       /**
-       * Fetches the trade history for a given address. Limited to a 7 day window.
-       * @param address Wallet Address
+       * Fetches the trade history across all markets for a given address. Limited to a 7 day window.
+       * @param address Wallet Address [defaults to operatingFor or walletSigner address if set]
        * @param fromTs start timestamp in seconds
        * @param toTs end timestamp in seconds
        * @returns User's trade history.
        */
-      tradeHistory: (args: { address: Address; fromTs?: bigint; toTs?: bigint }) => {
+      tradeHistory: (args: OmitBound<Parameters<typeof fetchTradeHistory>[0]> & OptionalAddress = {}) => {
         return fetchTradeHistory({
           graphClient: this.config.graphClient,
+          address: this.defaultAddress,
           ...args,
         })
       },
       /**
        * Fetches the open orders for a given address
-       * @param address Wallet Address
+       * @param address Wallet Address [defaults to operatingFor or walletSigner address if set]
        * @param markets List of {@link Markets} to fetch open orders for
        * @param pageParam Page number
        * @param pageSize Page size
        * @returns User's open orders.
        */
-      openOrders: (args: {
-        markets: Markets
-        address: Address
-        pageParam: number
-        pageSize: number
-        isMaker?: boolean
-      }) => {
+      openOrders: (args: OmitBound<Parameters<typeof fetchOpenOrders>[0]> & OptionalAddress) => {
         return fetchOpenOrders({
           graphClient: this.config.graphClient,
+          address: this.defaultAddress,
           ...args,
         })
       },
@@ -202,10 +184,10 @@ export class MarketsModule {
        * @param market Market Address
        * @returns Market 24hr volume data.
        */
-      market24hrData: ({ market }: { market: Address }) => {
+      market24hrData: (args: OmitBound<Parameters<typeof fetchMarket24hrData>[0]>) => {
         return fetchMarket24hrData({
           graphClient: this.config.graphClient,
-          market,
+          ...args,
         })
       },
       /**
@@ -213,10 +195,10 @@ export class MarketsModule {
        * @param markets List of market Addresses
        * @returns Markets 24hr volume data.
        */
-      markets24hrData: ({ markets }: { markets: Address[] }) => {
+      markets24hrData: (args: OmitBound<Parameters<typeof fetchMarkets24hrVolume>[0]>) => {
         return fetchMarkets24hrVolume({
           graphClient: this.config.graphClient,
-          markets,
+          ...args,
         })
       },
       /**
@@ -224,10 +206,10 @@ export class MarketsModule {
        * @param market Market Address
        * @returns Market 7d data.
        */
-      market7dData: ({ market }: { market: Address }) => {
+      market7dData: (args: OmitBound<Parameters<typeof fetchMarket7dData>[0]>) => {
         return fetchMarket7dData({
           graphClient: this.config.graphClient,
-          market,
+          ...args,
         })
       },
     }
@@ -239,7 +221,7 @@ export class MarketsModule {
        * Build a modify position transaction. Can be used to increase/decrease an
        * existing position, open/close a position and deposit or withdraw collateral.
        * @param marketAddress Market Address
-       * @param address Wallet Address
+       * @param address Wallet Address [defaults to operatingFor or walletSigner address if set]
        * @param marketSnapshots {@link MarketSnapshots}
        * @param marketOracles {@link MarketOracles}
        * @param collateralDelta BigInt - Collateral delta
@@ -255,36 +237,38 @@ export class MarketsModule {
        * @param referralFeeRate {@link ReferrerInterfaceFeeInfo}
        * @returns Modify position transaction data.
        */
-      modifyPosition: (args: OmitBound<BuildModifyPositionTxArgs>) => {
+      modifyPosition: (args: OmitBound<BuildModifyPositionTxArgs> & OptionalAddress) => {
+        const address = args.address ?? this.defaultAddress
+        throwIfZeroAddress(address)
+
         return buildModifyPositionTx({
           publicClient: this.config.publicClient,
           chainId: this.config.chainId,
           pythClient: this.config.pythClient,
           interfaceFeeRate: this.config.interfaceFeeBps,
           ...args,
+          address,
         })
       },
       /**
        * Build a submit VAA transaction
        * @param marketAddress Market Address
-       * @param address Wallet Address
        * @param marketSnapshots {@link MarketSnapshots}
        * @param marketOracles {@link MarketOracles}
        * @returns Submit VAA transaction data.
        */
-      submitVaa: ({ marketAddress, marketOracles, address }: OmitBound<BuildSubmitVaaTxArgs>) => {
+      submitVaa: ({ marketAddress, marketOracles }: OmitBound<BuildSubmitVaaTxArgs>) => {
         return buildSubmitVaaTx({
           chainId: this.config.chainId,
           pythClient: this.config.pythClient,
           marketAddress,
           marketOracles,
-          address,
         })
       },
       /**
        * Build a place order transaction. Can be used to set limit, stop loss and
        * take profit orders.
-       * @param address Wallet Address
+       * @param address Wallet Address [defaults to operatingFor or walletSigner address if set]
        * @param marketAddress Market Address
        * @param marketOracles {@link MarketOracles}
        * @param marketSnapshots {@link MarketSnapshots}
@@ -303,24 +287,33 @@ export class MarketsModule {
        * @param onCommitmentError Callback for commitment error
        * @returns Place order transaction data.
        */
-      placeOrder: (args: OmitBound<BuildPlaceOrderTxArgs>) => {
+      placeOrder: (args: OmitBound<BuildPlaceOrderTxArgs> & OptionalAddress) => {
+        const address = args.address ?? this.defaultAddress
+        throwIfZeroAddress(address)
+
         return buildPlaceOrderTx({
           chainId: this.config.chainId,
           pythClient: this.config.pythClient,
           publicClient: this.config.publicClient,
           interfaceFeeRate: this.config.interfaceFeeBps,
           ...args,
+          address,
         })
       },
       /**
        * Build a cancel order transaction
        * @param orderDetails {@link CancelOrderTuple[]} List of order details (as a tuple of Address and order nonce) to cancel
+       * @param address Wallet Address [defaults to operatingFor or walletSigner address if set]
        * @returns Cancel order transaction data.
        */
-      cancelOrder: (orderDetails: CancelOrderDetails[]) => {
+      cancelOrder: (args: OmitBound<BuildCancelOrderTxArgs> & OptionalAddress) => {
+        const address = args.address ?? this.defaultAddress
+        throwIfZeroAddress(address)
+
         return buildCancelOrderTx({
           chainId: this.config.chainId,
-          orderDetails,
+          ...args,
+          address,
         })
       },
     }
@@ -342,7 +335,7 @@ export class MarketsModule {
        * Send a modify position transaction. Can be used to increase/decrease an
        * existing position, open/close a position and deposit or withdraw collateral.
        * @param marketAddress Market Address
-       * @param address Wallet Address
+       * @param address Wallet Address [defaults to operatingFor or walletSigner address if set]
        * @param marketSnapshots {@link MarketSnapshots}
        * @param marketOracles {@link MarketOracles}
        * @param collateralDelta BigInt - Collateral delta
@@ -358,28 +351,27 @@ export class MarketsModule {
        * @param referralFeeRate {@link ReferrerInterfaceFeeInfo}
        * @returns Transaction Hash
        */
-      modifyPosition: async (args: OmitBound<BuildModifyPositionTxArgs>) => {
-        const tx = await this.build.modifyPosition(args)
+      modifyPosition: async (...args: Parameters<typeof this.build.modifyPosition>) => {
+        const tx = await this.build.modifyPosition(...args)
         const hash = await walletClient.sendTransaction({ ...tx, ...txOpts })
         return hash
       },
       /**
        * Send a submit VAA transaction
        * @param marketAddress Market Address
-       * @param address Wallet Address
        * @param marketSnapshots {@link MarketSnapshots}
        * @param marketOracles {@link MarketOracles}
        * @returns Transaction Hash.
        */
-      submitVaa: async ({ marketAddress, marketOracles, address }: OmitBound<BuildSubmitVaaTxArgs>) => {
-        const tx = await this.build.submitVaa({ marketAddress, marketOracles, address })
+      submitVaa: async (...args: Parameters<typeof this.build.submitVaa>) => {
+        const tx = await this.build.submitVaa(...args)
         const hash = await walletClient.sendTransaction({ ...tx, ...txOpts })
         return hash
       },
       /**
        * Send a place order transaction. Can be used to set limit, stop loss and
        * take profit orders.
-       * @param address Wallet Address
+       * @param address Wallet Address [defaults to operatingFor or walletSigner address if set]
        * @param marketAddress Market Address
        * @param marketOracles {@link MarketOracles}
        * @param marketSnapshots {@link MarketSnapshots}
@@ -398,18 +390,19 @@ export class MarketsModule {
        * @param onCommitmentError Callback for commitment error
        * @returns Transaction Hash.
        */
-      placeOrder: async (args: OmitBound<BuildPlaceOrderTxArgs>) => {
-        const tx = await this.build.placeOrder(args)
+      placeOrder: async (...args: Parameters<typeof this.build.placeOrder>) => {
+        const tx = await this.build.placeOrder(...args)
         const hash = await walletClient.sendTransaction({ ...tx, ...txOpts })
         return hash
       },
       /**
        * Send a cancel order transaction
        * @param orderDetails List of order details (as a tuple of Address and order nonce) to cancel
+       * @param address Wallet Address [defaults to operatingFor or walletSigner address if set]
        * @returns Transaction Hash.
        */
-      cancelOrder: async (orderDetails: CancelOrderDetails[]) => {
-        const tx = this.build.cancelOrder(orderDetails)
+      cancelOrder: async (...args: Parameters<typeof this.build.cancelOrder>) => {
+        const tx = this.build.cancelOrder(...args)
         const hash = await walletClient.sendTransaction({ ...tx, ...txOpts })
         return hash
       },

--- a/src/lib/markets/tx.ts
+++ b/src/lib/markets/tx.ts
@@ -259,7 +259,7 @@ export async function buildModifyPositionTx({
   const data = encodeFunctionData({
     functionName: 'invoke',
     abi: multiInvoker.abi,
-    args: [actions],
+    args: [address, actions],
   })
   return {
     data,
@@ -273,7 +273,6 @@ export type BuildSubmitVaaTxArgs = {
   pythClient: EvmPriceServiceConnection
   marketAddress: Address
   marketOracles: MarketOracles
-  address: Address
 }
 
 export async function buildSubmitVaaTx({ chainId, marketAddress, marketOracles, pythClient }: BuildSubmitVaaTxArgs) {
@@ -556,7 +555,7 @@ export async function buildPlaceOrderTx({
   const data = encodeFunctionData({
     functionName: 'invoke',
     abi: multiInvoker.abi,
-    args: [actions],
+    args: [address, actions],
   })
   return {
     data,
@@ -573,19 +572,18 @@ function buildCancelOrderActions(orders: CancelOrderDetails[]) {
   })
 }
 
-export function buildCancelOrderTx({
-  chainId,
-  orderDetails,
-}: {
+export type BuildCancelOrderTxArgs = {
   chainId: SupportedChainId
+  address: Address
   orderDetails: CancelOrderDetails[]
-}) {
+}
+export function buildCancelOrderTx({ chainId, address, orderDetails }: BuildCancelOrderTxArgs) {
   const actions: MultiInvokerAction[] = buildCancelOrderActions(orderDetails)
 
   const data = encodeFunctionData({
     functionName: 'invoke',
     abi: MultiInvokerAbi,
-    args: [actions],
+    args: [address, actions],
   })
   return {
     data,

--- a/src/lib/vaults/tx.ts
+++ b/src/lib/vaults/tx.ts
@@ -89,6 +89,7 @@ const buildPerformVaultUpdateTx = async ({
   vaultAddress,
   marketOracles,
   vaultSnapshots,
+  address,
 }: BaseVaultUpdateTxArgs & { baseAction: MultiInvokerAction }) => {
   const vaultType = chainVaultsWithAddress(chainId).find(({ vaultAddress: v }) => v === vaultAddress)
   if (!vaultType) throw new Error('Invalid Vault')
@@ -123,7 +124,7 @@ const buildPerformVaultUpdateTx = async ({
   const data = encodeFunctionData({
     abi: multiInvoker.abi,
     functionName: 'invoke',
-    args: [actions],
+    args: address ? [address, actions] : [actions],
   })
 
   return {

--- a/src/types/perennial.d.ts
+++ b/src/types/perennial.d.ts
@@ -6,6 +6,9 @@ import { MultiInvokerAbi } from '../abi/MultiInvoker.abi'
 export type JumpRateUtilizationCurve = AbiParametersToPrimitiveTypes<
   ExtractAbiFunction<typeof MarketAbi, 'riskParameter'>['outputs']
 >[0]['utilizationCurve']
-export type MultiInvokerAction = AbiParametersToPrimitiveTypes<
-  ExtractAbiFunction<typeof MultiInvokerAbi, 'invoke'>['inputs']
->[0][0]
+export type MultiInvokerAction = Exclude<
+  AbiParametersToPrimitiveTypes<ExtractAbiFunction<typeof MultiInvokerAbi, 'invoke'>['inputs']>[0][0],
+  string
+>
+
+export type OptionalAddress = { address?: Address }

--- a/src/utils/addressUtils.ts
+++ b/src/utils/addressUtils.ts
@@ -1,0 +1,6 @@
+import { Address, getAddress, isAddressEqual, zeroAddress } from 'viem'
+
+export function throwIfZeroAddress(address_: string | Address) {
+  const address = getAddress(address_)
+  if (isAddressEqual(address, zeroAddress)) throw new Error('Address cannot be zero')
+}


### PR DESCRIPTION
## Adds `MultiInvoker.invoke(address, actions)` Support

As of v2.2, the multiinvoker now supports calling on behalf of another user. To enable this, the user must first send a `updateOperator(<operator address>, <enabled>)` transaction to the multiinvoker. This transaction has been exposed in the Operator module

Addresses passed in to the various methods which hit the multiinvoker (most `markets.{build, write}` and `vaults.{build, write}` functions) will accept an address and will then invoke the actions for that address

## Adds `operatingFor` and signer address defaults
The SDK now supports an optional `operatingFor` address upon initialization. If this parameter is set, it will be passed through to the various read and write functions in the SDK. 

If there is no `operatingFor` address set, the SDK will default to the wallet signer address if available, and none are provided then the zero address. NOTE: Build/write functions _will throw an error_ if the zero address is used, since this is not a safe operation. In these cases, the caller _should_ pass the address directly (which will always be used as the first choice if available)