### PR TITLE
Break up transaction methods

### DIFF
--- a/src/Perennial/index.ts
+++ b/src/Perennial/index.ts
@@ -2,7 +2,7 @@ import { EvmPriceServiceConnection } from '@perennial/pyth-evm-js'
 import { GraphQLClient } from 'graphql-request'
 import { Address, Chain, PublicClient, Transport, WalletClient, createPublicClient, http } from 'viem'
 
-import { InterfaceFeeBps, SupportedChainId } from '..'
+import { SupportedChainId } from '..'
 import { DefaultChain, chainIdToChainMap } from '../constants/network'
 import { ContractsModule } from '../lib/contracts'
 import { MarketsModule } from '../lib/markets'
@@ -15,7 +15,6 @@ export type SDKConfig = {
   graphUrl: string
   pythUrl: string
   walletClient?: WalletClient
-  interfaceFeeBps?: InterfaceFeeBps
   operatingFor?: Address
 }
 
@@ -28,7 +27,6 @@ export type SDKConfig = {
  * @param config.chainId {@link SupportedChainId}
  * @param config.graphUrl SubGraph URL
  * @param config.pythUrl Pyth URL
- * @param config.interfaceFeeBps Interface Fee rates and recipient. See {@link interfaceFeeBps} for implementation examples.
  * @param config.operatingFor If set, the SDK will read data and send multi-invoker transactions on behalf of this address.
  *
  * @returns Perennial SDK instance
@@ -72,7 +70,6 @@ export default class PerennialSDK {
       walletClient: config.walletClient,
       graphClient: this._graphClient,
       pythClient: this._pythClient,
-      interfaceFeeBps: this.config.interfaceFeeBps,
       operatingFor: this.config.operatingFor,
     })
     this.vaults = new VaultsModule({

--- a/src/constants/markets.ts
+++ b/src/constants/markets.ts
@@ -345,3 +345,5 @@ export type InterfaceFee = {
   receiver: Address
   amount: bigint
 }
+
+export const FULL_CLOSE_MAGIC_VALUE = 0n

--- a/src/constants/markets.ts
+++ b/src/constants/markets.ts
@@ -339,3 +339,9 @@ export type InterfaceFeeBps = {
   feeAmount: { [key in PositionSide]: bigint }
   feeRecipientAddress: Address
 }
+
+export type InterfaceFee = {
+  unwrap: boolean
+  receiver: Address
+  amount: bigint
+}

--- a/src/constants/markets.ts
+++ b/src/constants/markets.ts
@@ -345,5 +345,3 @@ export type InterfaceFee = {
   receiver: Address
   amount: bigint
 }
-
-export const FULL_CLOSE_MAGIC_VALUE = 0n

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,15 +33,17 @@ export {
 // Market - Transactions
 export {
   buildCancelOrderTx,
-  buildModifyPositionTx,
+  buildUpdateMarketTx,
   buildLimitOrderTx,
   buildTakeProfitTx,
   buildStopLossTx,
   buildSubmitVaaTx,
-  type BuildModifyPositionTxArgs,
-  type BuildPlaceOrderTxArgs,
   type BuildSubmitVaaTxArgs,
   type CancelOrderDetails,
+  type BuildLimitOrderTxArgs,
+  type BuildTakeProfitTxArgs,
+  type BuildStopLossTxArgs,
+  type BuildUpdateMarketTxArgs,
 } from './lib/markets/tx'
 
 // Vault - Chain

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,9 @@ export {
 export {
   buildCancelOrderTx,
   buildModifyPositionTx,
-  buildPlaceOrderTx,
+  buildLimitOrderTx,
+  buildTakeProfitTx,
+  buildStopLossTx,
   buildSubmitVaaTx,
   type BuildModifyPositionTxArgs,
   type BuildPlaceOrderTxArgs,

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,8 +144,8 @@ export {
   orderTypes,
   triggerOrderTypes,
   interfaceFeeBps,
-  type ReferrerInterfaceFeeInfo,
   type InterfaceFeeBps,
+  type InterfaceFee,
 } from './constants/markets'
 
 /* #################### ABIs #################### */

--- a/src/lib/markets/constants.ts
+++ b/src/lib/markets/constants.ts
@@ -1,3 +1,4 @@
 import { Big6Math } from '../../utils'
 
 export const OrderExecutionDeposit = Big6Math.fromFloatString('20')
+export const TriggerOrderFullCloseMagicValue = 0n

--- a/src/lib/markets/index.ts
+++ b/src/lib/markets/index.ts
@@ -3,7 +3,6 @@ import { GraphQLClient } from 'graphql-request'
 import { Address, PublicClient, WalletClient, zeroAddress } from 'viem'
 
 import {
-  FULL_CLOSE_MAGIC_VALUE,
   InterfaceFee,
   OrderTypes,
   PositionSide,
@@ -16,7 +15,7 @@ import { notEmpty } from '../../utils'
 import { throwIfZeroAddress } from '../../utils/addressUtils'
 import { mergeMultiInvokerTxs } from '../../utils/multiinvoker'
 import { MarketOracles, MarketSnapshots, fetchMarketOracles, fetchMarketSnapshots } from './chain'
-import { OrderExecutionDeposit } from './constants'
+import { OrderExecutionDeposit, TriggerOrderFullCloseMagicValue } from './constants'
 import {
   OpenOrder,
   fetchActivePositionHistory,
@@ -326,7 +325,7 @@ export class MarketsModule {
             marketAddress: args.marketAddress,
             stopLossPrice: args.stopLossPrice,
             side: args.positionSide as PositionSide.long | PositionSide.short,
-            delta: FULL_CLOSE_MAGIC_VALUE,
+            delta: TriggerOrderFullCloseMagicValue,
             interfaceFee: args.stopLossFees?.interfaceFee,
             referralFee: args.stopLossFees?.referralFee,
             maxFee: OrderExecutionDeposit,
@@ -341,7 +340,7 @@ export class MarketsModule {
             marketAddress: args.marketAddress,
             takeProfitPrice: args.takeProfitPrice,
             side: args.positionSide as PositionSide.long | PositionSide.short,
-            delta: FULL_CLOSE_MAGIC_VALUE,
+            delta: TriggerOrderFullCloseMagicValue,
             maxFee: OrderExecutionDeposit,
             interfaceFee: args.takeProfitFees?.interfaceFee,
             referralFee: args.takeProfitFees?.referralFee,
@@ -541,7 +540,7 @@ export class MarketsModule {
         }
 
         if (args.takeProfitPrice && args.orderType !== OrderTypes.stopLoss) {
-          const takeProfitDelta = args.orderType === OrderTypes.limit ? FULL_CLOSE_MAGIC_VALUE : args.delta
+          const takeProfitDelta = args.orderType === OrderTypes.limit ? TriggerOrderFullCloseMagicValue : args.delta
 
           takeProfitTx = await buildTakeProfitTx({
             chainId: this.config.chainId,
@@ -557,7 +556,7 @@ export class MarketsModule {
         }
 
         if (args.stopLossPrice && args.orderType !== OrderTypes.takeProfit) {
-          const stopLossDelta = args.orderType === OrderTypes.limit ? FULL_CLOSE_MAGIC_VALUE : args.delta
+          const stopLossDelta = args.orderType === OrderTypes.limit ? TriggerOrderFullCloseMagicValue : args.delta
 
           stopLossTx = await buildStopLossTx({
             chainId: this.config.chainId,

--- a/src/lib/markets/index.ts
+++ b/src/lib/markets/index.ts
@@ -3,6 +3,7 @@ import { GraphQLClient } from 'graphql-request'
 import { Address, PublicClient, WalletClient, zeroAddress } from 'viem'
 
 import {
+  FULL_CLOSE_MAGIC_VALUE,
   InterfaceFee,
   OrderTypes,
   PositionSide,
@@ -325,7 +326,7 @@ export class MarketsModule {
             marketAddress: args.marketAddress,
             stopLossPrice: args.stopLossPrice,
             side: args.positionSide as PositionSide.long | PositionSide.short,
-            delta: -(args.positionAbs ?? 0n),
+            delta: FULL_CLOSE_MAGIC_VALUE,
             interfaceFee: args.stopLossFees?.interfaceFee,
             referralFee: args.stopLossFees?.referralFee,
             maxFee: OrderExecutionDeposit,
@@ -340,7 +341,7 @@ export class MarketsModule {
             marketAddress: args.marketAddress,
             takeProfitPrice: args.takeProfitPrice,
             side: args.positionSide as PositionSide.long | PositionSide.short,
-            delta: -(args.positionAbs ?? 0n),
+            delta: FULL_CLOSE_MAGIC_VALUE,
             maxFee: OrderExecutionDeposit,
             interfaceFee: args.takeProfitFees?.interfaceFee,
             referralFee: args.takeProfitFees?.referralFee,
@@ -540,7 +541,7 @@ export class MarketsModule {
         }
 
         if (args.takeProfitPrice && args.orderType !== OrderTypes.stopLoss) {
-          const takeProfitDelta = args.orderType === OrderTypes.limit ? -args.positionAbs : args.delta
+          const takeProfitDelta = args.orderType === OrderTypes.limit ? FULL_CLOSE_MAGIC_VALUE : args.delta
 
           takeProfitTx = await buildTakeProfitTx({
             chainId: this.config.chainId,
@@ -556,7 +557,7 @@ export class MarketsModule {
         }
 
         if (args.stopLossPrice && args.orderType !== OrderTypes.takeProfit) {
-          const stopLossDelta = args.orderType === OrderTypes.limit ? -args.positionAbs : args.delta
+          const stopLossDelta = args.orderType === OrderTypes.limit ? FULL_CLOSE_MAGIC_VALUE : args.delta
 
           stopLossTx = await buildStopLossTx({
             chainId: this.config.chainId,

--- a/src/lib/markets/index.ts
+++ b/src/lib/markets/index.ts
@@ -78,7 +78,6 @@ export type BuildPlaceOrderTxArgs = {
   stopLossPrice?: bigint
   takeProfitPrice?: bigint
   collateralDelta?: bigint
-  positionAbs: bigint
   triggerComparison: TriggerComparison
   limitOrderFees: {
     interfaceFee?: InterfaceFee
@@ -494,7 +493,6 @@ export class MarketsModule {
        * @param side Order side
        * @param collateralDelta BigInt - Collateral delta
        * @param delta BigInt - Position size delta
-       * @param positionAbs BigInt - Desired absolute position size
        * @param triggerComparison Trigger comparison for order execution. See {@link TriggerComparison}
        * @param limitOrderFees Object consisting of { interfaceFee: {@link InterfaceFee}, referralFee: {@link InterfaceFee} }
        * @param stopLossFees Object consisting of { interfaceFee: {@link InterfaceFee}, referralFee: {@link InterfaceFee} }
@@ -617,7 +615,6 @@ export class MarketsModule {
        * @param positionSide {@link PositionSide}
        * @param stopLoss BigInt - Optional stop loss price to fully close the position
        * @param takeProfit BigInt - Optional take profit price to fully close the position
-       * @param settlementFee BigInt - settlement fee
        * @param cancelOrderDetails List of open orders to cancel when modifying the position
        * @param interfaceFee {@link InterfaceFee}
        * @param referralFee {@link InterfaceFee}

--- a/src/lib/markets/index.ts
+++ b/src/lib/markets/index.ts
@@ -2,7 +2,7 @@ import { EvmPriceServiceConnection } from '@perennial/pyth-evm-js'
 import { GraphQLClient } from 'graphql-request'
 import { Address, PublicClient, WalletClient, zeroAddress } from 'viem'
 
-import { InterfaceFeeBps, OrderTypes, PositionSide, SupportedChainId, chainIdToChainMap } from '../../constants'
+import { OrderTypes, PositionSide, SupportedChainId, chainIdToChainMap } from '../../constants'
 import { OptionalAddress } from '../../types/perennial'
 import { notEmpty } from '../../utils'
 import { throwIfZeroAddress } from '../../utils/addressUtils'
@@ -44,7 +44,6 @@ type MarketsModuleConfig = {
   publicClient: PublicClient
   pythClient: EvmPriceServiceConnection
   walletClient?: WalletClient
-  interfaceFeeBps?: InterfaceFeeBps
   operatingFor?: Address
 }
 
@@ -56,7 +55,6 @@ type MarketsModuleConfig = {
  * @param config.graphClient GraphQL Client
  * @param config.pythClient Pyth Client
  * @param config.walletClient Wallet Client
- * @param config.interfaceFeeBps Interface Fee rates and recipient {@link InterfaceFeeBps}
  * @param config.operatingFor If set, the module will read data and send multi-invoker transactions on behalf of this address.
  * @returns Markets module instance
  */
@@ -240,10 +238,8 @@ export class MarketsModule {
        * @param takeProfit BigInt - Optional take profit price to fully close the position
        * @param settlementFee BigInt - settlement fee
        * @param cancelOrderDetails List of {@link OpenOrder[]} to cancel when modifying the position
-       * @param absDifferenceNotional BigInt - Absolute difference in notional
-       * @param interfaceFee Object consisting of interfaceFee, referrerFee and ecosystemFee amounts
-       * @param interfaceFeeRate {@link InterfaceFeeBps}
-       * @param referralFeeRate {@link ReferrerInterfaceFeeInfo}
+       * @param interfaceFee {@link InterfaceFee}
+       * @param referralFee {@link InterfaceFee}
        * @returns Modify position transaction data.
        */
       modifyPosition: async (args: OmitBound<BuildModifyPositionTxArgs> & OptionalAddress) => {
@@ -258,7 +254,6 @@ export class MarketsModule {
           chainId: this.config.chainId,
           pythClient: this.config.pythClient,
           publicClient: this.config.publicClient,
-          interfaceFeeRate: this.config.interfaceFeeBps,
           ...args,
           side: args.positionSide,
           address,
@@ -270,7 +265,6 @@ export class MarketsModule {
             chainId: this.config.chainId,
             pythClient: this.config.pythClient,
             publicClient: this.config.publicClient,
-            interfaceFeeRate: this.config.interfaceFeeBps,
             ...args,
             stopLoss: args.stopLoss,
             side: args.positionSide as PositionSide.long | PositionSide.short,
@@ -285,7 +279,6 @@ export class MarketsModule {
             chainId: this.config.chainId,
             pythClient: this.config.pythClient,
             publicClient: this.config.publicClient,
-            interfaceFeeRate: this.config.interfaceFeeBps,
             ...args,
             takeProfit: args.takeProfit,
             side: args.positionSide as PositionSide.long | PositionSide.short,
@@ -334,7 +327,6 @@ export class MarketsModule {
           chainId: this.config.chainId,
           pythClient: this.config.pythClient,
           publicClient: this.config.publicClient,
-          interfaceFeeRate: this.config.interfaceFeeBps,
           ...args,
           address,
         })
@@ -366,7 +358,6 @@ export class MarketsModule {
           chainId: this.config.chainId,
           pythClient: this.config.pythClient,
           publicClient: this.config.publicClient,
-          interfaceFeeRate: this.config.interfaceFeeBps,
           ...args,
           address,
         })
@@ -393,7 +384,6 @@ export class MarketsModule {
           chainId: this.config.chainId,
           pythClient: this.config.pythClient,
           publicClient: this.config.publicClient,
-          interfaceFeeRate: this.config.interfaceFeeBps,
           ...args,
           address,
         })
@@ -406,8 +396,8 @@ export class MarketsModule {
        * @param marketAddress Market Address
        * @param side {@link PositionSide}
        * @param delta BigInt - Position size delta
-       * @param referralFeeRate {@link ReferrerInterfaceFeeInfo}
-       * @param interfaceFeeRate {@link InterfaceFeeBps}
+       * @param interfaceFee {@link InterfaceFee}
+       * @param referralFee {@link InterfaceFee}
        * @param maxFee Maximum fee override - defaults to {@link OrderExecutionDeposit}
        * @param takeProfit BigInt - Stop loss price
        * @returns Take profit transaction data.
@@ -420,7 +410,6 @@ export class MarketsModule {
           chainId: this.config.chainId,
           pythClient: this.config.pythClient,
           publicClient: this.config.publicClient,
-          interfaceFeeRate: this.config.interfaceFeeBps,
           ...args,
           address,
         })
@@ -457,8 +446,8 @@ export class MarketsModule {
        * @param delta BigInt - Position size delta
        * @param positionAbs BigInt - Desired absolute position size
        * @param selectedLimitComparison Trigger comparison for order execution. See {@link TriggerComparison}
-       * @param referralFeeRate {@link ReferrerInterfaceFeeInfo}
-       * @param interfaceFeeRate {@link InterfaceFeeBps}
+       * @param interfaceFee {@link InterfaceFee}
+       * @param referralFee {@link InterfaceFee}
        * @param cancelOrderDetails {@link CancelOrderDetails}
        * @param onCommitmentError Callback for commitment error
        * @returns Place order transaction data.
@@ -475,7 +464,6 @@ export class MarketsModule {
             chainId: this.config.chainId,
             pythClient: this.config.pythClient,
             publicClient: this.config.publicClient,
-            interfaceFeeRate: this.config.interfaceFeeBps,
             ...args,
             limitPrice: args.limitPrice,
             address,
@@ -489,7 +477,6 @@ export class MarketsModule {
             chainId: this.config.chainId,
             pythClient: this.config.pythClient,
             publicClient: this.config.publicClient,
-            interfaceFeeRate: this.config.interfaceFeeBps,
             ...args,
             takeProfit: args.takeProfit,
             delta: takeProfitDelta,
@@ -504,7 +491,6 @@ export class MarketsModule {
             chainId: this.config.chainId,
             pythClient: this.config.pythClient,
             publicClient: this.config.publicClient,
-            interfaceFeeRate: this.config.interfaceFeeBps,
             ...args,
             stopLoss: args.stopLoss,
             delta: stopLossDelta,
@@ -562,9 +548,8 @@ export class MarketsModule {
        * @param settlementFee BigInt - settlement fee
        * @param cancelOrderDetails List of open orders to cancel when modifying the position
        * @param absDifferenceNotional BigInt - Absolute difference in notional
-       * @param interfaceFee Object consisting of interfaceFee, referrerFee and ecosystemFee amounts
-       * @param interfaceFeeRate {@link InterfaceFeeBps}
-       * @param referralFeeRate {@link ReferrerInterfaceFeeInfo}
+       * @param interfaceFee {@link InterfaceFee}
+       * @param referralFee {@link InterfaceFee}
        * @returns Transaction Hash
        */
       modifyPosition: async (...args: Parameters<typeof this.build.modifyPosition>) => {
@@ -584,9 +569,8 @@ export class MarketsModule {
        * @param positionAbs BigInt - Absolute size of desired position
        * @param side {@link PositionSide}
        * @param absDifferenceNotional BigInt - Absolute difference in notional
-       * @param interfaceFee Object consisting of interfaceFee, referrerFee and ecosystemFee amounts
-       * @param interfaceFeeRate {@link InterfaceFeeBps}
-       * @param referralFeeRate {@link ReferrerInterfaceFeeInfo}
+       * @param interfaceFee {@link InterfaceFee}
+       * @param referralFee {@link InterfaceFee}
        * @param onCommitmentError Callback for commitment error
        * @param publicClient Public Client
        * @returns Transaction Hash.
@@ -617,8 +601,8 @@ export class MarketsModule {
        * @param side {@link PositionSide}
        * @param delta BigInt - Position size delta
        * @param selectedLimitComparison Trigger comparison for order execution. See {@link TriggerComparison}
-       * @param referralFeeRate {@link ReferrerInterfaceFeeInfo}
-       * @param interfaceFeeRate {@link InterfaceFeeBps}
+       * @param interfaceFee {@link InterfaceFee}
+       * @param referralFee {@link InterfaceFee}
        * @param pythClient Pyth Client
        * @param marketOracles {@link MarketOracles}
        * @param marketSnapshots {@link MarketSnapshots}
@@ -640,8 +624,8 @@ export class MarketsModule {
        * @param marketAddress Market Address
        * @param side {@link PositionSide}
        * @param delta BigInt - Position size delta
-       * @param referralFeeRate {@link ReferrerInterfaceFeeInfo}
-       * @param interfaceFeeRate {@link InterfaceFeeBps}
+       * @param interfaceFee {@link InterfaceFee}
+       * @param referralFee {@link InterfaceFee}
        * @param maxFee Maximum fee override - defaults to {@link OrderExecutionDeposit}
        * @param stopLoss BigInt - Stop loss price
        * @returns Transaction hash.
@@ -659,8 +643,8 @@ export class MarketsModule {
        * @param marketAddress Market Address
        * @param side {@link PositionSide}
        * @param delta BigInt - Position size delta
-       * @param referralFeeRate {@link ReferrerInterfaceFeeInfo}
-       * @param interfaceFeeRate {@link InterfaceFeeBps}
+       * @param interfaceFee {@link InterfaceFee}
+       * @param referralFee {@link InterfaceFee}
        * @param maxFee Maximum fee override - defaults to {@link OrderExecutionDeposit}
        * @param takeProfit BigInt - Stop loss price
        * @returns Transaction hash.
@@ -687,8 +671,8 @@ export class MarketsModule {
        * @param delta BigInt - Position size delta
        * @param positionAbs BigInt - Desired absolute position size
        * @param selectedLimitComparison Trigger comparison for order execution. See TriggerComparison
-       * @param referralFeeRate Object consisting of referralCode, referralTarget, share, discount, tier
-       * @param interfaceFeeRate {@link InterfaceFeeBps}
+       * @param interfaceFee {@link InterfaceFee}
+       * @param referralFee {@link InterfaceFee}
        * @param cancelOrderDetails List of open orders to cancel when placing the order
        * @param onCommitmentError Callback for commitment error
        * @returns Transaction Hash.

--- a/src/lib/markets/index.ts
+++ b/src/lib/markets/index.ts
@@ -240,6 +240,8 @@ export class MarketsModule {
        * @param cancelOrderDetails List of {@link OpenOrder[]} to cancel when modifying the position
        * @param interfaceFee {@link InterfaceFee}
        * @param referralFee {@link InterfaceFee}
+       * @param stopLossFees Object consisting of { interfaceFee: {@link InterfaceFee}, referralFee: {@link InterfaceFee} }
+       * @param takeProfitFees Object consisting of { interfaceFee: {@link InterfaceFee}, referralFee: {@link InterfaceFee} }
        * @returns Modify position transaction data.
        */
       modifyPosition: async (args: OmitBound<BuildModifyPositionTxArgs> & OptionalAddress) => {
@@ -262,29 +264,33 @@ export class MarketsModule {
 
         if (args.stopLoss && isTaker && args.settlementFee) {
           stopLossTx = await buildStopLossTx({
-            chainId: this.config.chainId,
             pythClient: this.config.pythClient,
             publicClient: this.config.publicClient,
-            ...args,
+            address,
+            chainId: this.config.chainId,
+            marketAddress: args.marketAddress,
             stopLoss: args.stopLoss,
             side: args.positionSide as PositionSide.long | PositionSide.short,
-            maxFee: args.settlementFee * 2n,
             delta: -(args.positionAbs ?? 0n),
-            address,
+            interfaceFee: args.stopLossFees?.interfaceFee,
+            referralFee: args.stopLossFees?.referralFee,
+            maxFee: args.settlementFee * 2n,
           })
         }
 
         if (args.takeProfit && isTaker && args.settlementFee) {
           takeProfitTx = await buildTakeProfitTx({
-            chainId: this.config.chainId,
             pythClient: this.config.pythClient,
             publicClient: this.config.publicClient,
-            ...args,
+            address,
+            chainId: this.config.chainId,
+            marketAddress: args.marketAddress,
             takeProfit: args.takeProfit,
             side: args.positionSide as PositionSide.long | PositionSide.short,
-            maxFee: args.settlementFee * 2n,
             delta: -(args.positionAbs ?? 0n),
-            address,
+            maxFee: args.settlementFee * 2n,
+            interfaceFee: args.takeProfitFees?.interfaceFee,
+            referralFee: args.takeProfitFees?.referralFee,
           })
         }
 

--- a/src/lib/markets/tx.ts
+++ b/src/lib/markets/tx.ts
@@ -27,7 +27,7 @@ export type BuildUpdateMarketTxArgs = {
   address: Address
   collateralDelta?: bigint
   positionAbs?: bigint
-  side?: PositionSide
+  side: PositionSide
   interfaceFee?: InterfaceFee
   referralFee?: InterfaceFee
   onCommitmentError?: () => any
@@ -140,7 +140,7 @@ export type BuildModifyPositionTxArgs = {
   address: Address
   collateralDelta?: bigint
   positionAbs?: bigint
-  positionSide?: PositionSide
+  positionSide: PositionSide
   stopLoss?: bigint
   takeProfit?: bigint
   settlementFee?: bigint
@@ -148,6 +148,14 @@ export type BuildModifyPositionTxArgs = {
   absDifferenceNotional?: bigint
   interfaceFee?: InterfaceFee
   referralFee?: InterfaceFee
+  stopLossFees?: {
+    interfaceFee?: InterfaceFee
+    referralFee?: InterfaceFee
+  }
+  takeProfitFees?: {
+    interfaceFee?: InterfaceFee
+    referralFee?: InterfaceFee
+  }
   onCommitmentError?: () => any
 } & WithChainIdAndPublicClient
 

--- a/src/utils/positionUtils.ts
+++ b/src/utils/positionUtils.ts
@@ -443,6 +443,7 @@ export function calcTotalPositionChangeFee({
   positionDelta,
   direction,
   referrerInterfaceFeeDiscount,
+  interfaceFeeBps,
 }: {
   chainId: SupportedChainId
   positionDelta: bigint
@@ -450,6 +451,7 @@ export function calcTotalPositionChangeFee({
   direction: PositionSide
   positionStatus?: PositionStatus
   referrerInterfaceFeeDiscount: bigint
+  interfaceFeeBps?: InterfaceFeeBps
 }) {
   const tradeFee = calcTradeFee({
     positionDelta,
@@ -465,6 +467,7 @@ export function calcTotalPositionChangeFee({
     side: direction,
     referrerInterfaceFeeDiscount,
     referrerInterfaceFeeShare: 0n,
+    interfaceFeeBps,
   })
 
   const settlementFee = positionDelta !== 0n && marketSnapshot ? marketSnapshot.parameter.settlementFee : 0n


### PR DESCRIPTION
# New methods for creating transactions, interfaceFee changes.
- Interface and referral fees are now passed directly to transaction methods rather than being calculated internally.

- Previously, the entry point for placing a market order, adding/removing collateral, placing stop losses and take profits was through the `modifyPosition` method. Similarly, `placeOrder` acted as a catch all for placing SL/TP and limit orders. Both of these methods remain in place, however they are now abstractions over these more atomic methods. Each of these methods can be accessed via direct import or as a method on an instance of the SDK.

## Update Market
Equivalent to modifyPosition without the built in support for trigger orders (SL/TP).
- `buildUpdateMarketTx` 
- `sdk.build.updateMarket`
- `sdk.write.updateMarket`

## Limit Order
- `buildLimitOrderTx`
- `sdk.build.limitOrder`
- `sdk.write.limitOrder`

## Stop Loss
- `buildStopLossTx`
- `sdk.build.stopLoss`
- `sdk.write.stopLoss`

## Take Proft
- `buildTakeProfitTx`
- `sdk.build.takeProfit`
- `sdk.write.takeProfit`

### Linear ticket
https://linear.app/perennial/issue/PE-1407/[sdk]-clean-up-order-builder
