### PR TITLE
Add 'linkedDeposit' to trigger orders

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "packageManager": "pnpm@9.1.3",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "rimraf dist && pnpm run gen:lens-artifact && pnpm run gen:gql-typings && pnpm exec tsc -p tsconfig.build.json",
+    "clean": "rimraf dist cache artifacts",
+    "build": "pnpm run clean && pnpm run gen:lens-artifact && pnpm run gen:gql-typings && pnpm exec tsc -p tsconfig.build.json",
     "build:watch": "nodemon --exec 'pnpm exec tsc -p tsconfig.build.json' --watch src/ -e ts --ignore src/abi/",
     "prepublishOnly": "pnpm run build",
     "gen:lens-artifact": "pnpm exec hardhat compile && node ./scripts/lensAbiCopy.js && prettier --write ./src/abi/*Lens.abi.ts",


### PR DESCRIPTION
## Adds `linkedDeposit` to Open Orders function
Deposits are linked to trigger orders when the trigger order delta is greater than 0 and it is not a collateral trigger order. The linking works by looking for collateral deposits that occur within the same transaction to the same market.

```
    {
      account: '0x1defb9e9ae40d46c358dc0a185408dc178483851',
      market: '0x0142a8bff8d887fc4f04469fca6c66f5e0936ea7',
      nonce: '313',
      order_side: 2,
      order_comparison: 1,
      order_fee: '20000000',
      order_price: '4031758498',
      order_delta: '5000000',
      blockNumber: '51884825',
      blockTimestamp: '1717686883',
      transactionHash: '0xa117f1da03c5436d20b222ba3a6f66ba58822de8670c3256b9688a4fa039adf3',
      linkedDeposit: 220520385n
    }
```