### PR TITLE
Add functions to claim market fees and approve/unwrap DSU

### DIFF
--- a/src/abi/EmptysetReserve.abi.ts
+++ b/src/abi/EmptysetReserve.abi.ts
@@ -1,0 +1,249 @@
+export const EmptysetReserveAbi = [
+  {
+    inputs: [
+      {
+        internalType: 'Token18',
+        name: 'dsu_',
+        type: 'address',
+      },
+      {
+        internalType: 'Token6',
+        name: 'usdc_',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'constructor',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'version',
+        type: 'uint256',
+      },
+    ],
+    name: 'UInitializableAlreadyInitializedError',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'UInitializableNotInitializingError',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'UInitializableZeroVersionError',
+    type: 'error',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'UFixed18',
+        name: 'borrowAmount',
+        type: 'uint256',
+      },
+    ],
+    name: 'Borrow',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'version',
+        type: 'uint256',
+      },
+    ],
+    name: 'Initialized',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'UFixed18',
+        name: 'mintAmount',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'UFixed18',
+        name: 'costAmount',
+        type: 'uint256',
+      },
+    ],
+    name: 'Mint',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'UFixed18',
+        name: 'costAmount',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'UFixed18',
+        name: 'redeemAmount',
+        type: 'uint256',
+      },
+    ],
+    name: 'Redeem',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'UFixed18',
+        name: 'repayAmount',
+        type: 'uint256',
+      },
+    ],
+    name: 'Repay',
+    type: 'event',
+  },
+  {
+    inputs: [],
+    name: 'DSU',
+    outputs: [
+      {
+        internalType: 'Token18',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'USDC',
+    outputs: [
+      {
+        internalType: 'Token6',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    name: 'debt',
+    outputs: [
+      {
+        internalType: 'UFixed18',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'initialize',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'UFixed18',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'mint',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'UFixed18',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'redeem',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'redeemPrice',
+    outputs: [
+      {
+        internalType: 'UFixed18',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+      {
+        internalType: 'UFixed18',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    name: 'repay',
+    outputs: [],
+    stateMutability: 'pure',
+    type: 'function',
+  },
+] as const

--- a/src/constants/contracts.ts
+++ b/src/constants/contracts.ts
@@ -35,6 +35,12 @@ export const DSUAddresses: AddressMapping = {
   [base.id]: getAddress('0x7b4Adf64B0d60fF97D672E473420203D52562A84'),
 }
 
+export const EmptysetReserveAddresses: AddressMapping = {
+  [arbitrum.id]: getAddress('0x0d49c416103Cbd276d9c3cd96710dB264e3A0c27'),
+  [arbitrumSepolia.id]: getAddress('0x841d7C994aC0Bb17CcD65a021E686e3cFafE2118'),
+  [base.id]: getAddress('0x5FA881826AD000D010977645450292701bc2f56D'),
+}
+
 export const USDCAddresses: AddressMapping = {
   [arbitrum.id]: getAddress('0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8'),
   [arbitrumSepolia.id]: getAddress('0x16b38364bA6f55B6E150cC7f52D22E89643f3535'),

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,11 +87,13 @@ export {
   OracleFactoryAddresses,
   DSUAddresses,
   USDCAddresses,
+  EmptysetReserveAddresses,
 } from './constants/contracts'
 
 export {
   getUSDCContract,
   getDSUContract,
+  getEmptysetReserveContarct,
   getMultiInvokerContract,
   getMarketFactoryContract,
   getVaultFactoryContract,
@@ -159,6 +161,7 @@ export { VaultFactoryAbi } from './abi/VaultFactory.abi'
 export { VaultLensAbi } from './abi/VaultLens.abi'
 export { KeeperOracleAbi } from './abi/KeeperOracle.abi'
 export { PythFactoryAbi } from './abi/PythFactory.abi'
+export { EmptysetReserveAbi } from './abi/EmptysetReserve.abi'
 
 /* #################### Types #################### */
 

--- a/src/lib/contracts.ts
+++ b/src/lib/contracts.ts
@@ -1,6 +1,6 @@
 import { Address, GetContractReturnType, PublicClient, WalletClient, getContract } from 'viem'
 
-import { DefaultChain, KeeperOracleAbi, MarketAbi, OracleAbi, SupportedChainId, VaultAbi } from '..'
+import { DefaultChain, EmptysetReserveAbi, KeeperOracleAbi, MarketAbi, OracleAbi, SupportedChainId, VaultAbi } from '..'
 import { ERC20Abi } from '../abi/ERC20.abi'
 import { MarketFactoryAbi } from '../abi/MarketFactory.abi'
 import { MultiInvokerAbi } from '../abi/MultiInvoker.abi'
@@ -8,6 +8,7 @@ import { PythFactoryAbi } from '../abi/PythFactory.abi'
 import { VaultFactoryAbi } from '../abi/VaultFactory.abi'
 import {
   DSUAddresses,
+  EmptysetReserveAddresses,
   MarketFactoryAddresses,
   MultiInvokerAddresses,
   PythFactoryAddresses,
@@ -39,6 +40,20 @@ export const getUSDCContract = (chainId: SupportedChainId = DefaultChain.id, pub
   const contract = getContract({
     address: USDCAddresses[chainId],
     abi: ERC20Abi,
+    client: { public: publicClient },
+  })
+  return contract
+}
+/**
+ * Returns the EmptysetReserve contract instance.
+ * @param chainId {@link SupportedChainId}
+ * @param publicClient {@link PublicClient}
+ * @returns The EmptysetReserve contract instance.
+ */
+export const getEmptysetReserveContarct = (chainId: SupportedChainId = DefaultChain.id, publicClient: PublicClient) => {
+  const contract = getContract({
+    address: EmptysetReserveAddresses[chainId],
+    abi: EmptysetReserveAbi,
     client: { public: publicClient },
   })
   return contract
@@ -188,6 +203,13 @@ export class ContractsModule {
    */
   public getUSDCContract() {
     return getUSDCContract(this.config.chainId, this.config.publicClient)
+  }
+  /**
+   * Returns the EmptysetReserve contract instance.
+   * @returns The EmptysetReserve contract instance.
+   */
+  public getEmptysetReserveContract() {
+    return getEmptysetReserveContarct(this.config.chainId, this.config.publicClient)
   }
   /**
    * Returns the MultiInvoker contract instance.

--- a/src/lib/markets/index.ts
+++ b/src/lib/markets/index.ts
@@ -30,6 +30,7 @@ import {
 } from './graph'
 import {
   BuildCancelOrderTxArgs,
+  BuildClaimFeeTxArgs,
   BuildLimitOrderTxArgs,
   BuildStopLossTxArgs,
   BuildSubmitVaaTxArgs,
@@ -38,6 +39,7 @@ import {
   BuildUpdateMarketTxArgs,
   WithChainIdAndPublicClient,
   buildCancelOrderTx,
+  buildClaimFeeTx,
   buildLimitOrderTx,
   buildStopLossTx,
   buildSubmitVaaTx,
@@ -588,6 +590,15 @@ export class MarketsModule {
           address,
         })
       },
+
+      /**
+       * Build a claim fee transaction
+       * @notice This method only claims for the transaction sending address. OperatingFor is not supported
+       * @param marketAddress Market Address to claim fees for
+       */
+      claimFee: (args: OmitBound<BuildClaimFeeTxArgs>) => {
+        return buildClaimFeeTx({ ...args })
+      },
     }
   }
 
@@ -756,6 +767,16 @@ export class MarketsModule {
        */
       cancelOrder: async (...args: Parameters<typeof this.build.cancelOrder>) => {
         const tx = this.build.cancelOrder(...args)
+        const hash = await walletClient.sendTransaction({ ...tx, ...txOpts })
+        return hash
+      },
+
+      /**
+       * Send a claim fee transaction
+       * @param marketAddress Market Address to claim fees for
+       */
+      claimFee: async (...args: Parameters<typeof this.build.claimFee>) => {
+        const tx = this.build.claimFee(...args)
         const hash = await walletClient.sendTransaction({ ...tx, ...txOpts })
         return hash
       },

--- a/src/lib/markets/tx.ts
+++ b/src/lib/markets/tx.ts
@@ -1,7 +1,7 @@
 import { EvmPriceServiceConnection } from '@perennial/pyth-evm-js'
 import { Address, Hex, PublicClient, encodeFunctionData, getAddress } from 'viem'
 
-import { MultiInvokerAbi, PythFactoryAbi } from '../..'
+import { MarketAbi, MultiInvokerAbi, PythFactoryAbi } from '../..'
 import { PositionSide, SupportedChainId, TriggerComparison, addressToAsset } from '../../constants'
 import { InterfaceFee } from '../../constants'
 import { MultiInvokerAddresses, PythFactoryAddresses } from '../../constants/contracts'
@@ -336,6 +336,21 @@ export function buildCancelOrderTx({ chainId, address, orderDetails }: BuildCanc
   return {
     data,
     to: MultiInvokerAddresses[chainId],
+    value: 0n,
+  }
+}
+
+export type BuildClaimFeeTxArgs = {
+  marketAddress: Address
+}
+export function buildClaimFeeTx({ marketAddress }: BuildClaimFeeTxArgs) {
+  const data = encodeFunctionData({
+    functionName: 'claimFee',
+    abi: MarketAbi,
+  })
+  return {
+    data,
+    to: marketAddress,
     value: 0n,
   }
 }

--- a/src/lib/operators.ts
+++ b/src/lib/operators.ts
@@ -2,7 +2,10 @@ import { Address, PublicClient, WalletClient, encodeFunctionData, zeroAddress } 
 
 import {
   Big6Math,
+  DSUAddresses,
   ERC20Abi,
+  EmptysetReserveAbi,
+  EmptysetReserveAddresses,
   MarketFactoryAbi,
   MarketFactoryAddresses,
   MaxUint256,
@@ -12,11 +15,12 @@ import {
   VaultFactoryAbi,
   VaultFactoryAddresses,
   chainIdToChainMap,
+  getDSUContract,
+  getMarketFactoryContract,
   getMultiInvokerContract,
   getUSDCContract,
   getVaultFactoryContract,
 } from '..'
-import { getMarketFactoryContract } from '..'
 import { OptionalAddress } from '../types/shared'
 
 /**
@@ -44,6 +48,34 @@ export async function buildApproveUSDCTx({
     data,
     to: USDCAddresses[chainId],
     value: 0n,
+  }
+}
+
+/**
+ * Builds a transaction to approve DSU for the EmptysetReserve contract.
+ *
+ * @param chainId {@link SupportedChainId}
+ * @param suggestedAmount - The amount to approve in 18 decimal precision. Defaults to the maximum value.
+ *
+ * @returns Transaction calldata, destination address and transaction value.
+ */
+export async function buildApproveDSUReserveTx({
+  chainId,
+  suggestedAmount = MaxUint256,
+}: {
+  chainId: SupportedChainId
+  suggestedAmount?: bigint
+}) {
+  const data = encodeFunctionData({
+    abi: ERC20Abi,
+    functionName: 'approve',
+    args: [EmptysetReserveAddresses[chainId], Big6Math.abs(suggestedAmount)],
+  })
+
+  return {
+    to: DSUAddresses[chainId],
+    value: 0n,
+    data,
   }
 }
 
@@ -121,6 +153,25 @@ export async function buildUpdateMultiInvokerOperatorTx({
 }
 
 /**
+ * Builds a transaction to unwrap DSU into USDC.
+ * @param chainId {@link SupportedChainId}
+ * @param amount - The amount to unwrap in 18 decimal precision.
+ */
+export async function buildUnwrapDSUTx({ chainId, amount }: { chainId: SupportedChainId; amount: bigint }) {
+  const data = encodeFunctionData({
+    abi: EmptysetReserveAbi,
+    functionName: 'redeem',
+    args: [amount],
+  })
+
+  return {
+    to: EmptysetReserveAddresses[chainId],
+    value: 0n,
+    data,
+  }
+}
+
+/**
  * Gets the USDC allowance for the MultiInvoker contract.
  *
  * @param chainId {@link SupportedChainId}
@@ -140,6 +191,29 @@ export async function getUSDCAllowance({
 }) {
   const contract = getUSDCContract(chainId, publicClient)
   const allowance = await contract.read.allowance([address, MultiInvokerAddresses[chainId]])
+  return allowance
+}
+
+/**
+ * Gets the DSU allowance for the EmptysetReserve contract.
+ *
+ * @param chainId {@link SupportedChainId}
+ * @param publicClient Public Client
+ * @param address Wallet Address
+ *
+ * @returns The DSU allowance.
+ */
+export async function getDSUAllowance({
+  chainId,
+  publicClient,
+  address,
+}: {
+  chainId: SupportedChainId
+  publicClient: PublicClient
+  address: Address
+}) {
+  const contract = getDSUContract(chainId, publicClient)
+  const allowance = await contract.read.allowance([address, EmptysetReserveAddresses[chainId]])
   return allowance
 }
 
@@ -264,6 +338,19 @@ export class OperatorModule {
           publicClient: this.config.publicClient,
           ...args,
         }),
+
+      /**
+       * Get DSU allowance for the EmptysetReserve contract
+       * @param address Wallet Address [defaults to operatingFor or walletSigner address if set]
+       * @returns The DSU allowance
+       */
+      dsuAllowance: (args: OmitBound<Parameters<typeof getDSUAllowance>[0]> & OptionalAddress = {}) =>
+        getDSUAllowance({
+          chainId: this.config.chainId,
+          address: this.defaultAddress,
+          publicClient: this.config.publicClient,
+          ...args,
+        }),
       /**
        * Check if the provided address is approved to interact with the market factory
        * @param address Wallet Address [defaults to operatingFor or walletSigner address if set]
@@ -318,6 +405,15 @@ export class OperatorModule {
        */
       approveUSDC: ({ suggestedAmount }: { suggestedAmount?: bigint } = {}) =>
         buildApproveUSDCTx({ chainId: this.config.chainId, suggestedAmount }),
+
+      /**
+       * Build a transaction to approve DSU for the EmptysetReserve contract
+       * @param suggestedAmount - The amount to approve
+       * @returns Transaction calldata, destination address and transaction value
+       */
+      approveDSU: ({ suggestedAmount }: { suggestedAmount?: bigint } = {}) =>
+        buildApproveDSUReserveTx({ chainId: this.config.chainId, suggestedAmount }),
+
       /**
        * Build a transaction to approve the MarketFactory contract for the MultiInvoker contract
        * @returns Transaction calldata, destination address and transaction value
@@ -337,6 +433,13 @@ export class OperatorModule {
        */
       approveMultiInvokerOperatorTx: (args: OmitBound<Parameters<typeof buildUpdateMultiInvokerOperatorTx>[0]>) =>
         buildUpdateMultiInvokerOperatorTx({ chainId: this.config.chainId, ...args }),
+
+      /**
+       * Build a transaction to unwrap DSU into USDC
+       * @param amount - The amount to unwrap in 18 decimal precision
+       * @returns Transaction calldata, destination address and transaction value
+       */
+      unwrapDSU: ({ amount }: { amount: bigint }) => buildUnwrapDSUTx({ chainId: this.config.chainId, amount }),
     }
   }
 
@@ -366,6 +469,18 @@ export class OperatorModule {
         const hash = await walletClient.sendTransaction({ ...tx, ...txOpts })
         return hash
       },
+
+      /**
+       * approves DSU for the EmptysetReserve contract
+       * @param suggestedAmount - The amount to approve
+       * @returns Transaction hash
+       */
+      approveDSU: async ({ suggestedAmount }: { suggestedAmount?: bigint } = {}) => {
+        const tx = await this.build.approveDSU({ suggestedAmount })
+        const hash = await walletClient.sendTransaction({ ...tx, ...txOpts })
+        return hash
+      },
+
       /**
        * approves the MarketFactory contract for the MultiInvoker contract
        * @returns Transaction hash
@@ -393,6 +508,17 @@ export class OperatorModule {
        */
       approveMultiInvokerOperator: async (...args: Parameters<typeof this.build.approveMultiInvokerOperatorTx>) => {
         const tx = await this.build.approveMultiInvokerOperatorTx(...args)
+        const hash = await walletClient.sendTransaction({ ...tx, ...txOpts })
+        return hash
+      },
+
+      /**
+       * Build a transaction to unwrap DSU into USDC
+       * @param amount - The amount to unwrap in 18 decimal precision
+       * @returns Transaction calldata, destination address and transaction value
+       */
+      unwrapDSU: async (...args: Parameters<typeof this.build.unwrapDSU>) => {
+        const tx = await this.build.unwrapDSU(...args)
         const hash = await walletClient.sendTransaction({ ...tx, ...txOpts })
         return hash
       },


### PR DESCRIPTION
# Add Functions for Claiming Fees from Market
With v2.2 the markets now have a claimable fee for subtractive fees accrued by referrers and for liquidation fees for liquidators. These fees are disbursed to the user in DSU values - this PR allows for claiming, and then unwrapping DSU into USDC

## Operators
* `sdk.operators.read.dsuAllowance` - Returns the available allowance for the EmptysetReserve to pull the user's DSU balance
* `sdk.operators.{write,build}.approveDSU` - Approves the `amount` of DSU for spend by the EmptysetReserve
* `sdk.operators.{write,build}.unwrapDSU` - Unwraps the provided DSU amount into USDC

Note that DSU is an 18 decimal asset

## Markets
* `sdk.markets.{write,build}.claimFee` - Claims all available fees for the msg.sender. Note that operatingFor is not available here, and this function will _only_ claim fees for the msg.sender