### PR TITLE
Optional graph URL for sdk instantiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $ npm install @perennial/sdk --save
 To initalize the package you'll need to specify three `env` variables:
 
 - `RPC_URL_ARBITRUM`: A RPC url for Arbitrum which **must** support `eth_call`
-- `GRAPH_URL_ARBITRUM`: A hosted subgraph url for the Perennial protocol.
+- `GRAPH_URL_ARBITRUM`: A hosted subgraph url for the Perennial protocol. This argument is optional, but graph dependant read methods will throw an error if it is omitted.
   - You can find the Perennial subgraph repo [here](https://github.com/equilibria-xyz/perennial-v2-subgraph)
 - `PYTH_URL`: A url for Pyth
 

--- a/src/Perennial/index.ts
+++ b/src/Perennial/index.ts
@@ -12,7 +12,7 @@ import { VaultsModule } from '../lib/vaults'
 export type SDKConfig = {
   rpcUrl: string
   chainId: SupportedChainId
-  graphUrl: string
+  graphUrl?: string
   pythUrl: string
   walletClient?: WalletClient
   operatingFor?: Address
@@ -41,7 +41,7 @@ export default class PerennialSDK {
   private _publicClient: PublicClient<Transport<'http'>, Chain>
   private _walletClient?: WalletClient
   private _pythClient: EvmPriceServiceConnection
-  private _graphClient: GraphQLClient
+  private _graphClient: GraphQLClient | undefined
   public contracts: ContractsModule
   public markets: MarketsModule
   public vaults: VaultsModule
@@ -60,7 +60,7 @@ export default class PerennialSDK {
       timeout: 30000,
       priceFeedRequestConfig: { binary: true },
     })
-    this._graphClient = new GraphQLClient(config.graphUrl)
+    this._graphClient = config.graphUrl ? new GraphQLClient(config.graphUrl) : undefined
     this.contracts = new ContractsModule({
       chainId: config.chainId,
       publicClient: this._publicClient,
@@ -111,6 +111,7 @@ export default class PerennialSDK {
   }
 
   get graphClient() {
+    if (!this._graphClient) throw new Error('Graph client not initialized')
     return this._graphClient
   }
 

--- a/src/lib/markets/index.ts
+++ b/src/lib/markets/index.ts
@@ -103,7 +103,7 @@ export type BuildPlaceOrderTxArgs = {
 
 type MarketsModuleConfig = {
   chainId: SupportedChainId
-  graphClient: GraphQLClient
+  graphClient?: GraphQLClient
   publicClient: PublicClient
   pythClient: EvmPriceServiceConnection
   walletClient?: WalletClient
@@ -169,6 +169,10 @@ export class MarketsModule {
        * @returns User's PnL for an active position.
        */
       activePositionPnl: (args: OmitBound<Parameters<typeof fetchActivePositionPnl>[0]> & OptionalAddress) => {
+        if (!this.config.graphClient) {
+          throw new Error('Graph client required to fetch active position PnL.')
+        }
+
         return fetchActivePositionPnl({
           graphClient: this.config.graphClient,
           address: this.defaultAddress,
@@ -184,6 +188,10 @@ export class MarketsModule {
        * @returns User's position history for an active position.
        */
       activePositionHistory: (args: OmitBound<Parameters<typeof fetchActivePositionHistory>[0]> & OptionalAddress) => {
+        if (!this.config.graphClient) {
+          throw new Error('Graph client required to fetch active position history.')
+        }
+
         return fetchActivePositionHistory({
           graphClient: this.config.graphClient,
           address: this.defaultAddress,
@@ -199,6 +207,10 @@ export class MarketsModule {
        * @returns User's position history.
        */
       historicalPositions: (args: OmitBound<Parameters<typeof fetchHistoricalPositions>[0]> & OptionalAddress) => {
+        if (!this.config.graphClient) {
+          throw new Error('Graph client required to fetch historical positions.')
+        }
+
         return fetchHistoricalPositions({
           graphClient: this.config.graphClient,
           address: this.defaultAddress,
@@ -216,6 +228,10 @@ export class MarketsModule {
        * @returns User's sub positions.
        */
       subPositions: (args: OmitBound<Parameters<typeof fetchSubPositions>[0]> & OptionalAddress) => {
+        if (!this.config.graphClient) {
+          throw new Error('Graph client required to fetch sub positions.')
+        }
+
         return fetchSubPositions({
           graphClient: this.config.graphClient,
           address: this.defaultAddress,
@@ -230,6 +246,10 @@ export class MarketsModule {
        * @returns User's trade history.
        */
       tradeHistory: (args: OmitBound<Parameters<typeof fetchTradeHistory>[0]> & OptionalAddress = {}) => {
+        if (!this.config.graphClient) {
+          throw new Error('Graph client required to fetch trade history.')
+        }
+
         return fetchTradeHistory({
           graphClient: this.config.graphClient,
           address: this.defaultAddress,
@@ -245,6 +265,10 @@ export class MarketsModule {
        * @returns User's open orders.
        */
       openOrders: (args: OmitBound<Parameters<typeof fetchOpenOrders>[0]> & OptionalAddress) => {
+        if (!this.config.graphClient) {
+          throw new Error('Graph client required to fetch open orders.')
+        }
+
         return fetchOpenOrders({
           graphClient: this.config.graphClient,
           address: this.defaultAddress,
@@ -257,6 +281,10 @@ export class MarketsModule {
        * @returns Market 24hr volume data.
        */
       market24hrData: (args: OmitBound<Parameters<typeof fetchMarket24hrData>[0]>) => {
+        if (!this.config.graphClient) {
+          throw new Error('Graph client required to fetch market 24hr data.')
+        }
+
         return fetchMarket24hrData({
           graphClient: this.config.graphClient,
           ...args,
@@ -268,6 +296,10 @@ export class MarketsModule {
        * @returns Markets 24hr volume data.
        */
       markets24hrData: (args: OmitBound<Parameters<typeof fetchMarkets24hrVolume>[0]>) => {
+        if (!this.config.graphClient) {
+          throw new Error('Graph client required to fetch markets 24hr data.')
+        }
+
         return fetchMarkets24hrVolume({
           graphClient: this.config.graphClient,
           ...args,
@@ -279,6 +311,10 @@ export class MarketsModule {
        * @returns Market 7d data.
        */
       market7dData: (args: OmitBound<Parameters<typeof fetchMarket7dData>[0]>) => {
+        if (!this.config.graphClient) {
+          throw new Error('Graph client required to fetch market 7d data.')
+        }
+
         return fetchMarket7dData({
           graphClient: this.config.graphClient,
           ...args,

--- a/src/lib/vaults/index.ts
+++ b/src/lib/vaults/index.ts
@@ -71,7 +71,7 @@ type OmitBound<T> = Omit<T, 'chainId' | 'publicClient' | 'pythClient' | 'graphCl
 type VaultConfig = {
   chainId: SupportedChainId
   publicClient: PublicClient
-  graphClient: GraphQLClient
+  graphClient?: GraphQLClient
   pythClient: EvmPriceServiceConnection
   walletClient?: WalletClient
   operatingFor?: Address
@@ -154,6 +154,10 @@ export class VaultsModule {
        * @returns The vault 7d accumulations.
        */
       vault7dAccumulations: (args: OmitBound<Parameters<typeof fetchVault7dAccumulations>[0]>) => {
+        if (!this.config.graphClient) {
+          throw new Error('Graph client required to fetch vault7dAccumulations.')
+        }
+
         return fetchVault7dAccumulations({
           graphClient: this.config.graphClient,
           ...args,


### PR DESCRIPTION
# Makes `graphUrl` optional parameter for SDK instantiation.
Makes passing a graph URL optional upon SDK instantiation. Read methods that don't require the graph will still be accessible, graph dependent read methods will throw an error.

https://linear.app/perennial/issue/PE-1441/make-graph-url-optional-in-sdk-instantiation