### PR TITLE
Use new Hermes client

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "devDependencies": {
     "@equilibria/perennial-v2": "1.2.0-rc3",
     "@equilibria/perennial-v2-vault": "1.2.0-rc0",
-    "abitype": "^1.0.2",
     "@equilibria/root": "2.2.0",
     "@graphql-codegen/cli": "^3.3.1",
     "@graphql-codegen/client-preset": "^3.0.1",
@@ -39,6 +38,7 @@
     "@types/node": "^20.11.30",
     "@typescript-eslint/eslint-plugin": "^7.3.1",
     "@typescript-eslint/parser": "^7.3.1",
+    "abitype": "^1.0.2",
     "dotenv": "^16.3.1",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@microsoft/tsdoc": "^0.14.2",
-    "@perennial/pyth-evm-js": "^1.32.0-fork4",
+    "@pythnetwork/hermes-client": "^1.0.2",
     "date-fns": "^2.30.0",
     "graphql": "^16.6.0",
     "graphql-request": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,9 @@ importers:
       '@microsoft/tsdoc':
         specifier: ^0.14.2
         version: 0.14.2
-      '@perennial/pyth-evm-js':
-        specifier: ^1.32.0-fork4
-        version: 1.32.0-fork4
+      '@pythnetwork/hermes-client':
+        specifier: ^1.0.2
+        version: 1.0.2(axios@1.6.8)
       date-fns:
         specifier: ^2.30.0
         version: 2.30.0
@@ -25,7 +25,7 @@ importers:
         version: 6.1.0(graphql@16.8.1)
       viem:
         specifier: 2.9.9
-        version: 2.9.9(typescript@5.4.3)
+        version: 2.9.9(typescript@5.4.3)(zod@3.23.8)
     devDependencies:
       '@equilibria/perennial-v2':
         specifier: 1.2.0-rc3
@@ -38,7 +38,7 @@ importers:
         version: 2.2.0
       '@graphql-codegen/cli':
         specifier: ^3.3.1
-        version: 3.3.1(@babel/core@7.24.3)(@types/node@20.11.30)(graphql@16.8.1)
+        version: 3.3.1(@babel/core@7.24.3)(@types/node@20.11.30)(enquirer@2.4.1)(graphql@16.8.1)
       '@graphql-codegen/client-preset':
         specifier: ^3.0.1
         version: 3.0.1(graphql@16.8.1)
@@ -56,13 +56,13 @@ importers:
         version: 20.11.30
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.3.1
-        version: 7.3.1(@typescript-eslint/parser@7.3.1)(eslint@8.57.0)(typescript@5.4.3)
+        version: 7.3.1(@typescript-eslint/parser@7.3.1(eslint@8.57.0)(typescript@5.4.3))(eslint@8.57.0)(typescript@5.4.3)
       '@typescript-eslint/parser':
         specifier: ^7.3.1
         version: 7.3.1(eslint@8.57.0)(typescript@5.4.3)
       abitype:
         specifier: ^1.0.2
-        version: 1.0.2(typescript@5.4.3)
+        version: 1.0.2(typescript@5.4.3)(zod@3.23.8)
       dotenv:
         specifier: ^16.3.1
         version: 16.4.5
@@ -74,7 +74,7 @@ importers:
         version: 9.1.0(eslint@8.57.0)
       hardhat:
         specifier: ^2.17.0
-        version: 2.22.2(ts-node@10.9.2)(typescript@5.4.3)
+        version: 2.22.2(ts-node@10.9.2(@types/node@20.11.30)(typescript@5.4.3))(typescript@5.4.3)
       husky:
         specifier: ^9.0.11
         version: 9.0.11
@@ -101,7 +101,7 @@ importers:
         version: 0.25.13(typescript@5.4.3)
       typedoc-plugin-missing-exports:
         specifier: ^2.2.0
-        version: 2.2.0(typedoc@0.25.13)
+        version: 2.2.0(typedoc@0.25.13(typescript@5.4.3))
       typescript:
         specifier: 5.4.3
         version: 5.4.3
@@ -1011,18 +1011,12 @@ packages:
     resolution: {integrity: sha512-oDk93QCDGdxFRM8382Zdminzs44dg3M2+E5Np+JWkpqLDyJC9DviMh8F8mEJkYuUcUOGA5jHO5AJJ10MFWdbZw==}
     engines: {node: '>=10.12.0'}
 
-  '@perennial/price-service-client@1.8.2-fork2':
-    resolution: {integrity: sha512-EIJhD26pUQ2MHBpK6f77/QvVCGWXjRU+28wZ1rZ2uqhkEfWrEThkulT58gb3K6YBb8WhQDz3A/eV6gytVoiLYw==}
-
-  '@perennial/price-service-sdk@1.4.1-fork2':
-    resolution: {integrity: sha512-/9jDzHMtDUTNd7ao4NNp8jk3HWsPT55gg1HuIZvq+uIL04K93OX+bTEJaqeA2BV52qgLWV/nFVl59IhDyKo9fg==}
-
-  '@perennial/pyth-evm-js@1.32.0-fork4':
-    resolution: {integrity: sha512-nlaQa0DBwghJd9lrx2BgJEehrjyw7OLuY6IGpl4vO/7iFLTyHYvisPGX95d6jZb4Z5voXytoCFBKrPQcuAEkHA==}
-
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@pythnetwork/hermes-client@1.0.2':
+    resolution: {integrity: sha512-6t0jAMTFWDxpYYSqga8CXrovCNi9E4hJ1WVZFW8BD655TCLnyY8xlwa7PK30/SNF+nk1OrMYZ1ENdJwm2+JWRQ==}
 
   '@repeaterjs/repeater@3.0.4':
     resolution: {integrity: sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA==}
@@ -1200,6 +1194,12 @@ packages:
   '@whatwg-node/node-fetch@0.3.6':
     resolution: {integrity: sha512-w9wKgDO4C95qnXZRwZTfCmLWqyRnooGjcIwG0wADWjw9/HN0p7dtvtgSvItZtUyNteEvgTrd8QojNEqV6DAGTA==}
 
+  '@zodios/core@10.9.6':
+    resolution: {integrity: sha512-aH4rOdb3AcezN7ws8vDgBfGboZMk2JGGzEq/DtW65MhnRxyTGRuLJRWVQ/2KxDgWvV2F5oTkAS+5pnjKbl0n+A==}
+    peerDependencies:
+      axios: ^0.x || ^1.0.0
+      zod: ^3.x
+
   abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
 
@@ -1332,9 +1332,6 @@ packages:
     resolution: {integrity: sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==}
     engines: {node: '>=8'}
 
-  axios-retry@3.9.1:
-    resolution: {integrity: sha512-8PJDLJv7qTTMMwdnbMvrLYuvB47M81wRtxQmEdV5w4rgbTXTt+vtPkXwajOfOdSyv/wZICJOC+/UhXH4aQ/R+w==}
-
   axios@1.6.8:
     resolution: {integrity: sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==}
 
@@ -1416,9 +1413,6 @@ packages:
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
-
-  buffer@6.0.3:
-    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
@@ -1799,6 +1793,10 @@ packages:
 
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+
+  eventsource@2.0.2:
+    resolution: {integrity: sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==}
+    engines: {node: '>=12.0.0'}
 
   evp_bytestokey@1.0.3:
     resolution: {integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==}
@@ -2205,10 +2203,6 @@ packages:
     resolution: {integrity: sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==}
     engines: {node: '>=0.10.0'}
 
-  is-retry-allowed@2.2.0:
-    resolution: {integrity: sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==}
-    engines: {node: '>=10'}
-
   is-stream@3.0.0:
     resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -2233,11 +2227,6 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-
-  isomorphic-ws@4.0.1:
-    resolution: {integrity: sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==}
-    peerDependencies:
-      ws: '*'
 
   isomorphic-ws@5.0.0:
     resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
@@ -3371,6 +3360,9 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod@3.23.8:
+    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
+
 snapshots:
 
   '@aashutoshrathi/word-wrap@1.2.6': {}
@@ -3942,7 +3934,7 @@ snapshots:
       graphql: 16.8.1
       tslib: 2.5.3
 
-  '@graphql-codegen/cli@3.3.1(@babel/core@7.24.3)(@types/node@20.11.30)(graphql@16.8.1)':
+  '@graphql-codegen/cli@3.3.1(@babel/core@7.24.3)(@types/node@20.11.30)(enquirer@2.4.1)(graphql@16.8.1)':
     dependencies:
       '@babel/generator': 7.24.1
       '@babel/template': 7.24.0
@@ -3971,7 +3963,7 @@ snapshots:
       is-glob: 4.0.3
       jiti: 1.21.0
       json-to-pretty-yaml: 1.2.2
-      listr2: 4.0.5
+      listr2: 4.0.5(enquirer@2.4.1)
       log-symbols: 4.1.0
       micromatch: 4.0.5
       shell-quote: 1.8.1
@@ -4623,33 +4615,16 @@ snapshots:
       tslib: 2.6.2
       webcrypto-core: 1.7.8
 
-  '@perennial/price-service-client@1.8.2-fork2':
-    dependencies:
-      '@perennial/price-service-sdk': 1.4.1-fork2
-      '@types/ws': 8.5.10
-      axios: 1.6.8
-      axios-retry: 3.9.1
-      isomorphic-ws: 4.0.1(ws@8.16.0)
-      ts-log: 2.2.5
-      ws: 8.16.0
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - utf-8-validate
-
-  '@perennial/price-service-sdk@1.4.1-fork2': {}
-
-  '@perennial/pyth-evm-js@1.32.0-fork4':
-    dependencies:
-      '@perennial/price-service-client': 1.8.2-fork2
-      buffer: 6.0.3
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - utf-8-validate
-
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@pythnetwork/hermes-client@1.0.2(axios@1.6.8)':
+    dependencies:
+      '@zodios/core': 10.9.6(axios@1.6.8)(zod@3.23.8)
+      eventsource: 2.0.2
+      zod: 3.23.8
+    transitivePeerDependencies:
+      - axios
 
   '@repeaterjs/repeater@3.0.4': {}
 
@@ -4784,7 +4759,7 @@ snapshots:
     dependencies:
       '@types/node': 20.11.30
 
-  '@typescript-eslint/eslint-plugin@7.3.1(@typescript-eslint/parser@7.3.1)(eslint@8.57.0)(typescript@5.4.3)':
+  '@typescript-eslint/eslint-plugin@7.3.1(@typescript-eslint/parser@7.3.1(eslint@8.57.0)(typescript@5.4.3))(eslint@8.57.0)(typescript@5.4.3)':
     dependencies:
       '@eslint-community/regexpp': 4.10.0
       '@typescript-eslint/parser': 7.3.1(eslint@8.57.0)(typescript@5.4.3)
@@ -4799,6 +4774,7 @@ snapshots:
       natural-compare: 1.4.0
       semver: 7.6.0
       ts-api-utils: 1.3.0(typescript@5.4.3)
+    optionalDependencies:
       typescript: 5.4.3
     transitivePeerDependencies:
       - supports-color
@@ -4811,6 +4787,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 7.3.1
       debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.57.0
+    optionalDependencies:
       typescript: 5.4.3
     transitivePeerDependencies:
       - supports-color
@@ -4827,6 +4804,7 @@ snapshots:
       debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.57.0
       ts-api-utils: 1.3.0(typescript@5.4.3)
+    optionalDependencies:
       typescript: 5.4.3
     transitivePeerDependencies:
       - supports-color
@@ -4843,6 +4821,7 @@ snapshots:
       minimatch: 9.0.3
       semver: 7.6.0
       ts-api-utils: 1.3.0(typescript@5.4.3)
+    optionalDependencies:
       typescript: 5.4.3
     transitivePeerDependencies:
       - supports-color
@@ -4886,15 +4865,22 @@ snapshots:
       fast-url-parser: 1.1.3
       tslib: 2.6.2
 
+  '@zodios/core@10.9.6(axios@1.6.8)(zod@3.23.8)':
+    dependencies:
+      axios: 1.6.8
+      zod: 3.23.8
+
   abbrev@1.1.1: {}
 
-  abitype@1.0.0(typescript@5.4.3):
-    dependencies:
+  abitype@1.0.0(typescript@5.4.3)(zod@3.23.8):
+    optionalDependencies:
       typescript: 5.4.3
+      zod: 3.23.8
 
-  abitype@1.0.2(typescript@5.4.3):
-    dependencies:
+  abitype@1.0.2(typescript@5.4.3)(zod@3.23.8):
+    optionalDependencies:
       typescript: 5.4.3
+      zod: 3.23.8
 
   acorn-jsx@5.3.2(acorn@8.11.3):
     dependencies:
@@ -4986,11 +4972,6 @@ snapshots:
   asynckit@0.4.0: {}
 
   auto-bind@4.0.0: {}
-
-  axios-retry@3.9.1:
-    dependencies:
-      '@babel/runtime': 7.24.1
-      is-retry-allowed: 2.2.0
 
   axios@1.6.8:
     dependencies:
@@ -5118,11 +5099,6 @@ snapshots:
   buffer-xor@1.0.3: {}
 
   buffer@5.7.1:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
-
-  buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
@@ -5375,11 +5351,13 @@ snapshots:
   debug@4.3.4(supports-color@5.5.0):
     dependencies:
       ms: 2.1.2
+    optionalDependencies:
       supports-color: 5.5.0
 
   debug@4.3.4(supports-color@8.1.1):
     dependencies:
       ms: 2.1.2
+    optionalDependencies:
       supports-color: 8.1.1
 
   decamelize@1.2.0: {}
@@ -5601,6 +5579,8 @@ snapshots:
 
   eventemitter3@5.0.1: {}
 
+  eventsource@2.0.2: {}
+
   evp_bytestokey@1.0.3:
     dependencies:
       md5.js: 1.3.5
@@ -5709,7 +5689,7 @@ snapshots:
   flatted@3.3.1: {}
 
   follow-redirects@1.15.6(debug@4.3.4):
-    dependencies:
+    optionalDependencies:
       debug: 4.3.4(supports-color@5.5.0)
 
   foreground-child@3.1.1:
@@ -5866,7 +5846,7 @@ snapshots:
 
   graphql@16.8.1: {}
 
-  hardhat@2.22.2(ts-node@10.9.2)(typescript@5.4.3):
+  hardhat@2.22.2(ts-node@10.9.2(@types/node@20.11.30)(typescript@5.4.3))(typescript@5.4.3):
     dependencies:
       '@ethersproject/abi': 5.7.0
       '@metamask/eth-sig-util': 4.0.1
@@ -5907,12 +5887,13 @@ snapshots:
       solc: 0.7.3(debug@4.3.4)
       source-map-support: 0.5.21
       stacktrace-parser: 0.1.10
-      ts-node: 10.9.2(@types/node@20.11.30)(typescript@5.4.3)
       tsort: 0.0.1
-      typescript: 5.4.3
       undici: 5.28.3
       uuid: 8.3.2
       ws: 7.5.9
+    optionalDependencies:
+      ts-node: 10.9.2(@types/node@20.11.30)(typescript@5.4.3)
+      typescript: 5.4.3
     transitivePeerDependencies:
       - bufferutil
       - c-kzg
@@ -6093,8 +6074,6 @@ snapshots:
     dependencies:
       is-unc-path: 1.0.0
 
-  is-retry-allowed@2.2.0: {}
-
   is-stream@3.0.0: {}
 
   is-unc-path@1.0.0:
@@ -6112,10 +6091,6 @@ snapshots:
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
-
-  isomorphic-ws@4.0.1(ws@8.16.0):
-    dependencies:
-      ws: 8.16.0
 
   isomorphic-ws@5.0.0(ws@8.13.0):
     dependencies:
@@ -6225,7 +6200,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  listr2@4.0.5:
+  listr2@4.0.5(enquirer@2.4.1):
     dependencies:
       cli-truncate: 2.1.0
       colorette: 2.0.20
@@ -6235,6 +6210,8 @@ snapshots:
       rxjs: 7.8.1
       through: 2.3.8
       wrap-ansi: 7.0.0
+    optionalDependencies:
+      enquirer: 2.4.1
 
   listr2@8.0.1:
     dependencies:
@@ -6329,7 +6306,7 @@ snapshots:
   merge2@1.4.1: {}
 
   meros@1.3.0(@types/node@20.11.30):
-    dependencies:
+    optionalDependencies:
       '@types/node': 20.11.30
 
   micromatch@4.0.5:
@@ -6989,7 +6966,7 @@ snapshots:
 
   type-fest@3.13.1: {}
 
-  typedoc-plugin-missing-exports@2.2.0(typedoc@0.25.13):
+  typedoc-plugin-missing-exports@2.2.0(typedoc@0.25.13(typescript@5.4.3)):
     dependencies:
       typedoc: 0.25.13(typescript@5.4.3)
 
@@ -7051,17 +7028,18 @@ snapshots:
 
   value-or-promise@1.0.12: {}
 
-  viem@2.9.9(typescript@5.4.3):
+  viem@2.9.9(typescript@5.4.3)(zod@3.23.8):
     dependencies:
       '@adraffy/ens-normalize': 1.10.0
       '@noble/curves': 1.2.0
       '@noble/hashes': 1.3.2
       '@scure/bip32': 1.3.2
       '@scure/bip39': 1.2.1
-      abitype: 1.0.0(typescript@5.4.3)
+      abitype: 1.0.0(typescript@5.4.3)(zod@3.23.8)
       isows: 1.0.3(ws@8.13.0)
-      typescript: 5.4.3
       ws: 8.13.0
+    optionalDependencies:
+      typescript: 5.4.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -7203,3 +7181,5 @@ snapshots:
   yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@3.23.8: {}

--- a/src/Perennial/index.ts
+++ b/src/Perennial/index.ts
@@ -1,4 +1,4 @@
-import { EvmPriceServiceConnection } from '@perennial/pyth-evm-js'
+import { HermesClient } from '@pythnetwork/hermes-client'
 import { GraphQLClient } from 'graphql-request'
 import { Address, Chain, PublicClient, Transport, WalletClient, createPublicClient, http } from 'viem'
 
@@ -40,7 +40,7 @@ export default class PerennialSDK {
   private _currentChainId: SupportedChainId = DefaultChain.id
   private _publicClient: PublicClient<Transport<'http'>, Chain>
   private _walletClient?: WalletClient
-  private _pythClient: EvmPriceServiceConnection
+  private _pythClient: HermesClient
   private _graphClient: GraphQLClient | undefined
   public contracts: ContractsModule
   public markets: MarketsModule
@@ -56,9 +56,8 @@ export default class PerennialSDK {
         multicall: true,
       },
     })
-    this._pythClient = new EvmPriceServiceConnection(config.pythUrl, {
+    this._pythClient = new HermesClient(config.pythUrl, {
       timeout: 30000,
-      priceFeedRequestConfig: { binary: true },
     })
     this._graphClient = config.graphUrl ? new GraphQLClient(config.graphUrl) : undefined
     this.contracts = new ContractsModule({

--- a/src/constants/network.ts
+++ b/src/constants/network.ts
@@ -1,4 +1,4 @@
-import { EvmPriceServiceConnection } from '@perennial/pyth-evm-js'
+import { HermesClient } from '@pythnetwork/hermes-client'
 import { Chain, PublicClient } from 'viem'
 import { arbitrum, arbitrumSepolia, base } from 'viem/chains'
 
@@ -11,11 +11,10 @@ export const chainIdToChainMap = {
 }
 
 export type SupportedChainId = (typeof SupportedChainIds)[number]
-export const BackupPythClient = new EvmPriceServiceConnection(
+export const BackupPythClient = new HermesClient(
   `${typeof window !== 'undefined' ? window.location.origin : 'https://app.perennial.finance'}/api/pyth`,
   {
     timeout: 30000,
-    priceFeedRequestConfig: { binary: true },
   },
 )
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -264,4 +264,4 @@ export {
   formatDateRelative,
 } from './utils/timeUtils'
 
-export { PriceFeed, EvmPriceServiceConnection } from '@perennial/pyth-evm-js'
+export { PriceUpdate, HermesClient } from '@pythnetwork/hermes-client'

--- a/src/lib/markets/chain.ts
+++ b/src/lib/markets/chain.ts
@@ -1,4 +1,4 @@
-import { EvmPriceServiceConnection } from '@perennial/pyth-evm-js'
+import { HermesClient } from '@pythnetwork/hermes-client'
 import { Address, PublicClient, getAddress, getContractAddress, maxUint256, zeroAddress } from 'viem'
 
 import {
@@ -139,7 +139,7 @@ export async function fetchMarketSnapshots({
   onSuccess,
 }: {
   publicClient: PublicClient
-  pythClient: EvmPriceServiceConnection
+  pythClient: HermesClient
   chainId: SupportedChainId
   address: Address
   marketOracles?: MarketOracles
@@ -301,7 +301,7 @@ async function fetchMarketSnapshotsAfterSettle({
   address: Address
   marketOracles: MarketOracles
   publicClient: PublicClient
-  pyth: EvmPriceServiceConnection
+  pyth: HermesClient
   onPythError?: () => void
   resetPythError?: () => void
 }) {

--- a/src/lib/markets/index.ts
+++ b/src/lib/markets/index.ts
@@ -1,4 +1,4 @@
-import { EvmPriceServiceConnection } from '@perennial/pyth-evm-js'
+import { HermesClient } from '@pythnetwork/hermes-client'
 import { GraphQLClient } from 'graphql-request'
 import { Address, PublicClient, WalletClient, zeroAddress } from 'viem'
 
@@ -55,7 +55,7 @@ export type BuildModifyPositionTxArgs = {
   marketAddress: Address
   marketSnapshots?: MarketSnapshots
   marketOracles?: MarketOracles
-  pythClient: EvmPriceServiceConnection
+  pythClient: HermesClient
   address: Address
   collateralDelta?: bigint
   positionAbs?: bigint
@@ -105,7 +105,7 @@ type MarketsModuleConfig = {
   chainId: SupportedChainId
   graphClient?: GraphQLClient
   publicClient: PublicClient
-  pythClient: EvmPriceServiceConnection
+  pythClient: HermesClient
   walletClient?: WalletClient
   operatingFor?: Address
   supportedMarkets?: SupportedAsset[]

--- a/src/lib/markets/tx.ts
+++ b/src/lib/markets/tx.ts
@@ -1,4 +1,4 @@
-import { EvmPriceServiceConnection } from '@perennial/pyth-evm-js'
+import { HermesClient } from '@pythnetwork/hermes-client'
 import { Address, Hex, PublicClient, encodeFunctionData, getAddress } from 'viem'
 
 import { MarketAbi, MultiInvokerAbi, PythFactoryAbi } from '../..'
@@ -28,7 +28,7 @@ export type BuildUpdateMarketTxArgs = {
   marketAddress: Address
   marketSnapshots?: MarketSnapshots
   marketOracles?: MarketOracles
-  pythClient: EvmPriceServiceConnection
+  pythClient: HermesClient
   address: Address
   collateralDelta?: bigint
   positionAbs?: bigint
@@ -143,7 +143,7 @@ export async function buildUpdateMarketTx({
 
 export type BuildSubmitVaaTxArgs = {
   chainId: SupportedChainId
-  pythClient: EvmPriceServiceConnection
+  pythClient: HermesClient
   marketAddress: Address
   marketOracles: MarketOracles
 }

--- a/src/lib/vaults/chain.ts
+++ b/src/lib/vaults/chain.ts
@@ -1,4 +1,4 @@
-import { EvmPriceServiceConnection } from '@perennial/pyth-evm-js'
+import { HermesClient } from '@pythnetwork/hermes-client'
 import {
   Address,
   PublicClient,
@@ -50,7 +50,7 @@ export async function fetchVaultSnapshots({
   address: Address
   marketOracles?: MarketOracles
   publicClient: PublicClient
-  pythClient: EvmPriceServiceConnection
+  pythClient: HermesClient
   onError?: () => void
   onSuccess?: () => void
 }) {
@@ -123,7 +123,7 @@ const fetchVaultSnapshotsAfterSettle = async ({
   address: Address
   marketOracles: MarketOracles
   publicClient: PublicClient
-  pyth: EvmPriceServiceConnection
+  pyth: HermesClient
   onPythError?: () => void
   resetPythError?: () => void
 }) => {

--- a/src/lib/vaults/index.ts
+++ b/src/lib/vaults/index.ts
@@ -1,4 +1,4 @@
-import { EvmPriceServiceConnection } from '@perennial/pyth-evm-js'
+import { HermesClient } from '@pythnetwork/hermes-client'
 import { GraphQLClient } from 'graphql-request'
 import { Address, PublicClient, WalletClient, zeroAddress } from 'viem'
 
@@ -35,7 +35,7 @@ export const fetchVaultCommitments = async ({
   publicClient,
 }: {
   chainId: SupportedChainId
-  pythClient: EvmPriceServiceConnection
+  pythClient: HermesClient
   preMarketSnapshots: VaultSnapshot['pre']['marketSnapshots']
   marketOracles: MarketOracles
   publicClient: PublicClient
@@ -72,7 +72,7 @@ type VaultConfig = {
   chainId: SupportedChainId
   publicClient: PublicClient
   graphClient?: GraphQLClient
-  pythClient: EvmPriceServiceConnection
+  pythClient: HermesClient
   walletClient?: WalletClient
   operatingFor?: Address
 }

--- a/src/lib/vaults/tx.ts
+++ b/src/lib/vaults/tx.ts
@@ -1,4 +1,4 @@
-import { EvmPriceServiceConnection } from '@perennial/pyth-evm-js'
+import { HermesClient } from '@pythnetwork/hermes-client'
 import { Address, PublicClient, encodeFunctionData, zeroAddress } from 'viem'
 
 import { fetchVaultCommitments } from '.'
@@ -13,7 +13,7 @@ import { VaultSnapshot, VaultSnapshots, fetchVaultSnapshots } from './chain'
 type BaseVaultUpdateTxArgs = {
   chainId: SupportedChainId
   publicClient: PublicClient
-  pythClient: EvmPriceServiceConnection
+  pythClient: HermesClient
   vaultAddress: Address
   address?: Address
   marketOracles?: MarketOracles


### PR DESCRIPTION
## Update Pyth to new Hermes Client
This PR removes the custom `@perennial/pyth-evm-js` package in favor of Pyth's new [Hermes Client](https://www.npmjs.com/package/@pythnetwork/hermes-client). For downstream users the functionality should be unchanged, except for live price streaming where Pyth has switched from WebSockets to Server-Sent Events

Please refer to thew Pyth documentation for using the Server-Sent Events if needed