### PR TITLE
Add position start tx hash, order deposit/withdrawalTotal

### DIFF
--- a/src/graphQueries/markets.ts
+++ b/src/graphQueries/markets.ts
@@ -8,14 +8,14 @@ export const PositionDataFragment = gql(`
       collateral_subAccumulation_funding, collateral_subAccumulation_interest, collateral_subAccumulation_makerPositionFee, collateral_subAccumulation_makerExposure, fee_subAccumulation_settlement
       fee_subAccumulation_trade, fee_subAccumulation_additive, fee_subAccumulation_triggerOrder, fee_subAccumulation_liquidation
     }
-    openOrder: orders(first: 1, orderBy: orderId, orderDirection: asc) { executionPrice }
+    openOrder: orders(first: 1, orderBy: orderId, orderDirection: asc) { executionPrice, transactionHashes }
     closeOrder: orders(where: { newMaker: 0, newLong: 0, newShort: 0, oracleVersion_: { valid: true } }, first: 1, orderBy: orderId, orderDirection: asc) { oracleVersion { timestamp }, liquidation }
   }
 `)
 
 export const OrderDataFragbment = gql(`
   fragment OrderData on Order {
-    orderId, market { id }, account { id }, maker, long, short, collateral, executionPrice, oracleVersion { timestamp, valid }, newMaker, newLong, newShort, liquidation, transactionHashes, startCollateral
+    orderId, market { id }, account { id }, maker, long, short, collateral, executionPrice, oracleVersion { timestamp, valid }, newMaker, newLong, newShort, liquidation, transactionHashes, startCollateral, depositTotal, withdrawalTotal
     position { startMaker, startLong, startShort }
     accumulation {
       collateral_accumulation, fee_accumulation, collateral_subAccumulation_offset, collateral_subAccumulation_pnl,

--- a/src/lib/markets/graph.ts
+++ b/src/lib/markets/graph.ts
@@ -218,6 +218,7 @@ export async function fetchActivePositionsPnl({
       startPrice: userMarketSnapshot.prices[0],
       positionId: userMarketSnapshot.local.currentId,
       startCollateral,
+      startTransactionHash: null,
       totalPnl: pendingTradeImpactAsOffset,
       totalFees: pendingTradeFee + pendingOrderSettlementFee,
       totalNotional: calcNotional(userMarketSnapshot.prices[0], pendingDelta),
@@ -430,6 +431,7 @@ function processGraphPosition(
     startPrice: BigInt(graphPosition?.openOrder.at(0)?.executionPrice ?? 0n),
     startCollateral: BigInt(graphPosition.startCollateral),
     netDeposits,
+    startTransactionHash: graphPosition?.openOrder.at(0)?.transactionHashes.at(0) ?? null,
     // PNL
     netPnl,
     netPnlPercent: percentDenominator !== 0n ? Big6Math.div(netPnl, percentDenominator) : 0n,
@@ -618,6 +620,8 @@ function processOrder(market: SupportedMarket, order: OrderDataFragment) {
     executionPriceWithOffset: priceWithImpact,
     startCollateral: BigInt(order.startCollateral),
     netDeposits: collateral,
+    depositTotal: BigInt(order.depositTotal),
+    withdrawalTotal: BigInt(order.withdrawalTotal),
     // PNL
     netPnl,
     netPnlPercent: percentDenominator !== 0n ? Big6Math.div(netPnl, percentDenominator) : 0n,


### PR DESCRIPTION
# Add new position and order fields
* Adds `startTransactionHash` to Positions, this will be the transaction hash for the opening order for the position, or `null` if it is not yet confirmed
* Adds `depositTotal` and `withdrawalTotal` to orders. These are the individual components which make up the `netDeposits` field