### PR TITLE
Add markets open check

### DIFF
--- a/src/constants/network.ts
+++ b/src/constants/network.ts
@@ -13,6 +13,7 @@ export type SupportedChainId = (typeof SupportedChainIds)[number]
 export const BackupPythClient = new HermesClient('https://hermes.pyth.network', {
   timeout: 30000,
 })
+export const PythPriceFeedUrl = 'https://benchmarks.pyth.network/v1/price_feeds/'
 
 export const chains: { [chainId in SupportedChainId]: Chain } = {
   [arbitrum.id]: arbitrum,

--- a/src/lib/markets/index.ts
+++ b/src/lib/markets/index.ts
@@ -28,6 +28,7 @@ import {
   fetchSubPositions,
   fetchTradeHistory,
 } from './graph'
+import { getMarketHoursData } from './metadata'
 import {
   BuildCancelOrderTxArgs,
   BuildClaimFeeTxArgs,
@@ -336,6 +337,9 @@ export class MarketsModule {
           markets: this.config.supportedMarkets,
           ...args,
         })
+      },
+      marketHoursData: (market: SupportedMarket) => {
+        return getMarketHoursData(market)
       },
     }
   }

--- a/src/lib/markets/index.ts
+++ b/src/lib/markets/index.ts
@@ -28,7 +28,7 @@ import {
   fetchSubPositions,
   fetchTradeHistory,
 } from './graph'
-import { getMarketHoursData } from './metadata'
+import { getPythMarketHours } from './metadata'
 import {
   BuildCancelOrderTxArgs,
   BuildClaimFeeTxArgs,
@@ -338,8 +338,14 @@ export class MarketsModule {
           ...args,
         })
       },
-      marketHoursData: (market: SupportedMarket) => {
-        return getMarketHoursData(market)
+      /**
+       * Fetches data for if a market is open, when it opens and closes
+       * from the pyth. Relevant for markets that observe traditional trading hours.
+       * @param pythFeedId string
+       * @returns {@link MarketHours}
+       */
+      pythMarketHours: (pythFeedId: string) => {
+        return getPythMarketHours(pythFeedId)
       },
     }
   }

--- a/src/lib/markets/metadata.ts
+++ b/src/lib/markets/metadata.ts
@@ -1,0 +1,17 @@
+import { AssetMetadata } from '../..'
+import { SupportedMarket } from '../../constants'
+import { PythPriceFeedUrl } from '../../constants'
+
+export const getMarketHoursData = async (
+  market: SupportedMarket,
+): Promise<{
+  is_open: boolean
+  next_open: number
+  next_close: number
+} | null> => {
+  const { pythFeedId } = AssetMetadata[market]
+  const res = await fetch(`${PythPriceFeedUrl}${pythFeedId})`)
+  const marketData = await res.json()
+  if (!marketData || !marketData.market_hours) return null
+  return marketData.market_hours
+}

--- a/src/lib/markets/metadata.ts
+++ b/src/lib/markets/metadata.ts
@@ -1,15 +1,12 @@
-import { AssetMetadata } from '../..'
-import { SupportedMarket } from '../../constants'
 import { PythPriceFeedUrl } from '../../constants'
 
-export const getMarketHoursData = async (
-  market: SupportedMarket,
-): Promise<{
+export type MarketHours = {
   is_open: boolean
   next_open: number
   next_close: number
-} | null> => {
-  const { pythFeedId } = AssetMetadata[market]
+}
+
+export const getPythMarketHours = async (pythFeedId: string): Promise<MarketHours | null> => {
   const res = await fetch(`${PythPriceFeedUrl}${pythFeedId})`)
   const marketData = await res.json()
   if (!marketData || !marketData.market_hours) return null


### PR DESCRIPTION
# Adds `marketHoursData` method to market reads.

Adds method to query data around whether or not a given market is open. This will be relevant for markets that observe traditional market hours.