### PR TITLE
use array of backup clients

### DIFF
--- a/src/lib/markets/chain.ts
+++ b/src/lib/markets/chain.ts
@@ -140,7 +140,7 @@ export async function fetchMarketSnapshots({
   onSuccess,
 }: {
   publicClient: PublicClient
-  pythClient: HermesClient
+  pythClient: HermesClient | HermesClient[]
   chainId: SupportedChainId
   address: Address
   marketOracles?: MarketOracles
@@ -156,7 +156,7 @@ export async function fetchMarketSnapshots({
     address,
     marketOracles,
     publicClient,
-    pyth: pythClient,
+    pyth: Array.isArray(pythClient) ? pythClient : [pythClient],
     onPythError: onError,
     resetPythError: onSuccess,
   })
@@ -300,7 +300,7 @@ async function fetchMarketSnapshotsAfterSettle({
   address: Address
   marketOracles: MarketOracles
   publicClient: PublicClient
-  pyth: HermesClient
+  pyth: HermesClient[]
   onPythError?: () => void
   resetPythError?: () => void
 }) {

--- a/src/lib/markets/graph.ts
+++ b/src/lib/markets/graph.ts
@@ -68,7 +68,7 @@ export async function fetchActivePositionsPnl({
   marketSnapshots?: MarketSnapshots
   markToMarket?: boolean
   chainId: SupportedChainId
-  pythClient: HermesClient
+  pythClient: HermesClient | HermesClient[]
   publicClient: PublicClient
   graphClient: GraphQLClient
 }): Promise<

--- a/src/lib/markets/index.ts
+++ b/src/lib/markets/index.ts
@@ -55,7 +55,7 @@ export type BuildModifyPositionTxArgs = {
   marketAddress: Address
   marketSnapshots?: MarketSnapshots
   marketOracles?: MarketOracles
-  pythClient: HermesClient
+  pythClient: HermesClient | HermesClient[]
   address: Address
   collateralDelta?: bigint
   positionAbs?: bigint
@@ -105,7 +105,7 @@ type MarketsModuleConfig = {
   chainId: SupportedChainId
   graphClient?: GraphQLClient
   publicClient: PublicClient
-  pythClient: HermesClient
+  pythClient: HermesClient[]
   walletClient?: WalletClient
   operatingFor?: Address
   supportedMarkets: SupportedMarket[]

--- a/src/lib/markets/tx.ts
+++ b/src/lib/markets/tx.ts
@@ -28,7 +28,7 @@ export type BuildUpdateMarketTxArgs = {
   marketAddress: Address
   marketSnapshots?: MarketSnapshots
   marketOracles?: MarketOracles
-  pythClient: HermesClient
+  pythClient: HermesClient | HermesClient[]
   address: Address
   collateralDelta?: bigint
   positionAbs?: bigint
@@ -140,7 +140,7 @@ export async function buildUpdateMarketTx({
 
 export type BuildSubmitVaaTxArgs = {
   chainId: SupportedChainId
-  pythClient: HermesClient
+  pythClient: HermesClient | HermesClient[]
   marketAddress: Address
   marketOracles: MarketOracles
 }

--- a/src/lib/vaults/chain.ts
+++ b/src/lib/vaults/chain.ts
@@ -50,7 +50,7 @@ export async function fetchVaultSnapshots({
   address: Address
   marketOracles?: MarketOracles
   publicClient: PublicClient
-  pythClient: HermesClient
+  pythClient: HermesClient | HermesClient[]
   onError?: () => void
   onSuccess?: () => void
 }) {
@@ -68,7 +68,7 @@ export async function fetchVaultSnapshots({
     address,
     marketOracles,
     publicClient,
-    pyth: pythClient,
+    pyth: Array.isArray(pythClient) ? pythClient : [pythClient],
     onPythError: onError,
     resetPythError: onSuccess,
   })
@@ -123,7 +123,7 @@ const fetchVaultSnapshotsAfterSettle = async ({
   address: Address
   marketOracles: MarketOracles
   publicClient: PublicClient
-  pyth: HermesClient
+  pyth: HermesClient[]
   onPythError?: () => void
   resetPythError?: () => void
 }) => {

--- a/src/lib/vaults/index.ts
+++ b/src/lib/vaults/index.ts
@@ -34,7 +34,7 @@ export const fetchVaultCommitments = async ({
   publicClient,
 }: {
   chainId: SupportedChainId
-  pythClient: HermesClient
+  pythClient: HermesClient | HermesClient[]
   preMarketSnapshots: VaultSnapshot['pre']['marketSnapshots']
   marketOracles: MarketOracles
   publicClient: PublicClient
@@ -71,7 +71,7 @@ type VaultConfig = {
   chainId: SupportedChainId
   publicClient: PublicClient
   graphClient?: GraphQLClient
-  pythClient: HermesClient
+  pythClient: HermesClient[]
   walletClient?: WalletClient
   operatingFor?: Address
 }

--- a/src/lib/vaults/tx.ts
+++ b/src/lib/vaults/tx.ts
@@ -13,7 +13,7 @@ import { VaultSnapshot, VaultSnapshots, fetchVaultSnapshots } from './chain'
 type BaseVaultUpdateTxArgs = {
   chainId: SupportedChainId
   publicClient: PublicClient
-  pythClient: HermesClient
+  pythClient: HermesClient | HermesClient[]
   vaultAddress: Address
   address?: Address
   marketOracles?: MarketOracles

--- a/src/utils/pythUtils.ts
+++ b/src/utils/pythUtils.ts
@@ -44,8 +44,8 @@ export const getRecentVaa = async ({
       })
       .filter(notEmpty)
   } catch (err: any) {
-    const nextPyth = Array.isArray(pyth_) ? pyth_.slice(1) : null
-    const useBackup = nextPyth !== null && nextPyth.length > 0
+    const nextPyth = Array.isArray(pyth_) ? pyth_.slice(1) : []
+    const useBackup = nextPyth.length > 0
     console.error('Pyth Recent VAA Error', `Use backup: ${useBackup}`, err)
 
     if (useBackup) return getRecentVaa({ pyth: nextPyth, feeds })
@@ -126,8 +126,8 @@ export const buildCommitmentsForOracles = async ({
       })
       .flat()
   } catch (err: any) {
-    const nextPyth = Array.isArray(pyth_) ? pyth_.slice(1) : null
-    const useBackup = nextPyth !== null && nextPyth.length > 0
+    const nextPyth = Array.isArray(pyth_) ? pyth_.slice(1) : []
+    const useBackup = nextPyth.length > 0
     console.error('Pyth Recent VAA Error', `Use backup: ${useBackup}`, err)
 
     if (useBackup) {

--- a/src/utils/pythUtils.ts
+++ b/src/utils/pythUtils.ts
@@ -45,9 +45,10 @@ export const getRecentVaa = async ({
       .filter(notEmpty)
   } catch (err: any) {
     const nextPyth = Array.isArray(pyth_) ? pyth_.slice(1) : null
-    console.error('Pyth Recent VAA Error', `Use backup: ${Boolean(nextPyth)}`, err)
+    const useBackup = nextPyth !== null && nextPyth.length > 0
+    console.error('Pyth Recent VAA Error', `Use backup: ${useBackup}`, err)
 
-    if (nextPyth) return getRecentVaa({ pyth: nextPyth, feeds })
+    if (useBackup) return getRecentVaa({ pyth: nextPyth, feeds })
 
     throw err
   }
@@ -126,8 +127,10 @@ export const buildCommitmentsForOracles = async ({
       .flat()
   } catch (err: any) {
     const nextPyth = Array.isArray(pyth_) ? pyth_.slice(1) : null
-    console.error('Pyth Recent VAA Error', `Use backup: ${Boolean(nextPyth)}`, err)
-    if (nextPyth) {
+    const useBackup = nextPyth !== null && nextPyth.length > 0
+    console.error('Pyth Recent VAA Error', `Use backup: ${useBackup}`, err)
+
+    if (useBackup) {
       return buildCommitmentsForOracles({
         chainId,
         pyth: nextPyth,


### PR DESCRIPTION
# Allow for Array of Pyth Clients
Due to provider downtime for Pyth clients that can be independent of Pyth overall downtime, it is sometimes useful to have an array of fallback Pyth clients to use to request data.

This PR allows for arrays of `HermesClient`s to be passed in when originally only one was allowed. If an array of clients are passed in, it will work down the list of clients until a request succeeds or there are no more clients to use.