### PR TITLE
Warning in `placeOrder` if no price is set.

### DIFF
--- a/src/lib/markets/index.ts
+++ b/src/lib/markets/index.ts
@@ -567,6 +567,10 @@ export class MarketsModule {
         const address = args.address ?? this.defaultAddress
         throwIfZeroAddress(address)
 
+        if (!args.limitPrice && !args.stopLossPrice && !args.takeProfitPrice) {
+          throw new Error('At least one of limitPrice, stopLossPrice or takeProfitPrice must be set')
+        }
+
         let updateMarketTx
         let limitOrderTx
         let takeProfitTx

--- a/src/lib/markets/index.ts
+++ b/src/lib/markets/index.ts
@@ -568,7 +568,7 @@ export class MarketsModule {
         throwIfZeroAddress(address)
 
         if (!args.limitPrice && !args.stopLossPrice && !args.takeProfitPrice) {
-          throw new Error('At least one of limitPrice, stopLossPrice or takeProfitPrice must be set')
+          console.warn('PlaceOrder: No order type specified. Please provide a limit, stop loss or take profit price.')
         }
 
         let updateMarketTx


### PR DESCRIPTION
# Warning n `placeOrder` method if no price is set.

Since all the `{limit,stop,takeProfit}` prices are optional, users are confused as to what params need to be set. This change logs an error if there isn't at least one of these arguments provided.