### PR TITLE
Trade fee updates

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -279,7 +279,6 @@ export {
   calcSkew,
   calcFundingRates,
   calcTradeFee,
-  calcPriceImpactFromTradeFee,
   calcEstExecutionPrice,
   calcInterfaceFee,
   calcTotalPositionChangeFee,

--- a/src/lib/markets/graph.ts
+++ b/src/lib/markets/graph.ts
@@ -131,8 +131,7 @@ export async function fetchActivePositionsPnl({
     const pendingTradeFeeData = calcTradeFee({
       positionDelta: pendingDelta,
       marketSnapshot,
-      isMaker: side === PositionSide.maker,
-      direction: side,
+      side: side,
       usePreGlobalPosition: pendingDelta !== 0n,
     })
     const pendingTradeImpactAsOffset = -1n * pendingTradeFeeData.tradeImpact.total

--- a/src/lib/markets/graph.ts
+++ b/src/lib/markets/graph.ts
@@ -135,10 +135,10 @@ export async function fetchActivePositionsPnl({
       direction: side,
       usePreGlobalPosition: pendingDelta !== 0n,
     })
-    const pendingTradeImpactAsOffset = -1n * pendingTradeFeeData.tradeImpact
+    const pendingTradeImpactAsOffset = -1n * pendingTradeFeeData.tradeImpact.total
     const pendingOrderCollateral = userMarketSnapshot.pendingOrder.collateral
     const pendingOrderSettlementFee = marketSettlementFees[market].totalCost
-    const pendingTradeFee = pendingTradeFeeData.tradeFee
+    const pendingTradeFee = pendingTradeFeeData.tradeFee.total
     const pendingAdditiveFee = 0n
 
     const graphMarketAccount = marketAccounts.find((ma) => getAddress(ma.market.id) === marketAddress)

--- a/src/utils/positionUtils.ts
+++ b/src/utils/positionUtils.ts
@@ -293,7 +293,7 @@ export const calcFundingRates = (fundingRate: bigint = 0n) => {
 export type TradeFeeInfo = {
   tradeFee: {
     total: bigint
-    basisPoints: bigint
+    tradeFeePct: bigint
     components: {
       referralFee: bigint
     }
@@ -301,7 +301,7 @@ export type TradeFeeInfo = {
   tradeImpact: {
     total: bigint
     impactPerPosition: bigint
-    basisPoints: bigint
+    impactPerPositionPct: bigint
     components: {
       proportionalFee: bigint
       linearFee: bigint
@@ -337,7 +337,7 @@ export const calcTradeFee = ({
   let tradeFeeInfo = {
     tradeFee: {
       total: 0n,
-      basisPoints: 0n,
+      tradeFeePct: 0n,
       components: {
         referralFee: 0n,
       },
@@ -345,7 +345,7 @@ export const calcTradeFee = ({
     tradeImpact: {
       total: 0n,
       impactPerPosition: 0n,
-      basisPoints: 0n,
+      impactPerPositionPct: 0n,
       components: {
         proportionalFee: 0n,
         linearFee: 0n,
@@ -384,7 +384,7 @@ export const calcTradeFee = ({
     tradeFeeInfo = {
       tradeFee: {
         total: tradeFee,
-        basisPoints: feeBasisPoints,
+        tradeFeePct: feeBasisPoints,
         components: {
           referralFee: referralFeeNotional,
         },
@@ -392,7 +392,7 @@ export const calcTradeFee = ({
       tradeImpact: {
         total: 0n,
         impactPerPosition: 0n,
-        basisPoints: 0n,
+        impactPerPositionPct: 0n,
         components: {
           proportionalFee: makerProportionalFee,
           linearFee: makerLinearFee,
@@ -429,7 +429,7 @@ export const calcTradeFee = ({
   tradeFeeInfo = {
     tradeFee: {
       total: tradeFee,
-      basisPoints: feeBasisPoints,
+      tradeFeePct: feeBasisPoints,
       components: {
         referralFee: referralFeeNotional,
       },
@@ -437,7 +437,7 @@ export const calcTradeFee = ({
     tradeImpact: {
       total: tradeImpact,
       impactPerPosition: priceImpact,
-      basisPoints: priceImpactPct,
+      impactPerPositionPct: priceImpactPct,
       components: {
         proportionalFee: takerProportionalFee,
         linearFee: takerLinearFee,

--- a/src/utils/positionUtils.ts
+++ b/src/utils/positionUtils.ts
@@ -412,7 +412,7 @@ export const calcTradeFee = ({
   const feeBasisPoints = !Big6Math.isZero(tradeFee) ? Big6Math.div(tradeFee, notional) : 0n
   const tradeImpact = takerLinearFee + takerProportionalFee + takerAdiabaticFee
   const priceImpact = positionDelta !== 0n ? Big6Math.div(tradeImpact, Big6Math.abs(positionDelta)) : 0n
-  const priceImpactPct = priceImpact !== 0n ? Big6Math.div(priceImpact, Big6Math.abs(notional)) : 0n
+  const priceImpactPct = priceImpact !== 0n ? Big6Math.div(tradeImpact, notional) : 0n
 
   tradeFeeInfo = {
     tradeFee: {

--- a/src/utils/positionUtils.ts
+++ b/src/utils/positionUtils.ts
@@ -294,9 +294,6 @@ export type TradeFeeInfo = {
   tradeFee: {
     total: bigint
     tradeFeePct: bigint
-    components: {
-      referralFee: bigint
-    }
   }
   tradeImpact: {
     total: bigint
@@ -324,7 +321,6 @@ export const calcTradeFee = ({
   marketSnapshot,
   isMaker,
   direction,
-  referralFee = 0n,
   usePreGlobalPosition = false,
 }: {
   positionDelta: bigint
@@ -338,9 +334,6 @@ export const calcTradeFee = ({
     tradeFee: {
       total: 0n,
       tradeFeePct: 0n,
-      components: {
-        referralFee: 0n,
-      },
     },
     tradeImpact: {
       total: 0n,
@@ -379,15 +372,11 @@ export const calcTradeFee = ({
     const makerLinearFee = Big6Math.mul(notional, makerFee.linearFee)
     const tradeFee = Big6Math.mul(marketMakerFee, notional)
     const feeBasisPoints = !Big6Math.isZero(tradeFee) ? Big6Math.div(tradeFee, notional) : 0n
-    const referralFeeNotional = Big6Math.mul(tradeFee, referralFee)
 
     tradeFeeInfo = {
       tradeFee: {
         total: tradeFee,
         tradeFeePct: feeBasisPoints,
-        components: {
-          referralFee: referralFeeNotional,
-        },
       },
       tradeImpact: {
         total: 0n,
@@ -420,7 +409,6 @@ export const calcTradeFee = ({
 
   const takerLinearFee = Big6Math.mul(notional, takerFee.linearFee)
   const tradeFee = Big6Math.mul(marketTakerFee, notional)
-  const referralFeeNotional = Big6Math.mul(tradeFee, referralFee)
   const feeBasisPoints = !Big6Math.isZero(tradeFee) ? Big6Math.div(tradeFee, notional) : 0n
   const tradeImpact = takerLinearFee + takerProportionalFee + takerAdiabaticFee
   const priceImpact = positionDelta !== 0n ? Big6Math.div(tradeImpact, Big6Math.abs(positionDelta)) : 0n
@@ -430,9 +418,6 @@ export const calcTradeFee = ({
     tradeFee: {
       total: tradeFee,
       tradeFeePct: feeBasisPoints,
-      components: {
-        referralFee: referralFeeNotional,
-      },
     },
     tradeImpact: {
       total: tradeImpact,


### PR DESCRIPTION
### Updates trade fee calculations for v2.3

#### Changes:
- Removes `calcPriceImpactFromTradeFee`. Price impact and price impact percent  are returned from `calcTradeFee` under `tradeImpact.impactPerPosition` and `tradeImpact.impactPerPositionPct`

- Updated `calcTradeFee` return type:
```type TradeFeeInfo = {
  tradeFee: {
    total: bigint
    pct: bigint
  }
  tradeImpact: {
    total: bigint
    pct: bigint
    perPosition: bigint
    components: {
      proportionalFee: bigint
      linearFee: bigint
      adiabaticFee: bigint
    }
  }
}
```
