### PR TITLE
Add signer override if wallet client is present

### DIFF
--- a/examples/intents/withdrawCollateralAccount.ts
+++ b/examples/intents/withdrawCollateralAccount.ts
@@ -1,0 +1,51 @@
+import { addHours } from 'date-fns'
+import { config as dotenvConfig } from 'dotenv'
+import path from 'path'
+import { Hex, createWalletClient, getAddress, http } from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+import { arbitrumSepolia } from 'viem/chains'
+
+import Perennial, { Big6Math, timeToSeconds } from '../../'
+
+dotenvConfig({ path: path.resolve(__dirname, '../../.env.local') })
+;(BigInt.prototype as any).toJSON = function () {
+  return this.toString()
+}
+
+async function run() {
+  const walletClient = createWalletClient({
+    account: privateKeyToAccount(process.env.PRIVATE_KEY! as Hex),
+    chain: arbitrumSepolia,
+    transport: http(process.env.RPC_URL_ARBITRUM_SEPOLIA!),
+  })
+  const address = walletClient.account.address
+
+  const sdk = new Perennial({
+    chainId: arbitrumSepolia.id,
+    rpcUrl: process.env.RPC_URL_ARBITRUM_SEPOLIA!,
+    graphUrl: process.env.GRAPH_URL_ARBITRUM!,
+    pythUrl: process.env.PYTH_URL!,
+    cryptexUrl: process.env.CRYPTEX_URL!,
+    operatingFor: address,
+    walletClient,
+  })
+
+  const controller = sdk.contracts.getControllerContract()
+
+  const { signature, withdrawal } = await sdk.collateralAccounts.sign.withdrawal({
+    amount: Big6Math.fromFloatString('1'),
+    unwrap: true,
+    maxFee: Big6Math.fromFloatString('10'),
+    expiry: timeToSeconds(addHours(new Date(), 1), true),
+    overrides: { signer: walletClient.account.address },
+  })
+
+  // The account sending the transaction can be different from the one that the collateral account is deployed for
+  const { request } = await controller.simulate.withdrawWithSignature([withdrawal.message, signature], {
+    account: walletClient.account,
+  })
+  const txHash = await walletClient.writeContract(request)
+  console.log('Transaction sent:', txHash)
+}
+
+run()

--- a/src/lib/collateralAccounts/index.ts
+++ b/src/lib/collateralAccounts/index.ts
@@ -3,6 +3,7 @@ import { Address, PublicClient, WalletClient, zeroAddress } from 'viem'
 import { SupportedChainId, chainIdToChainMap } from '../../constants'
 import { OptionalAddress } from '../../types/shared'
 import { throwIfZeroAddress } from '../../utils/addressUtils'
+import { addSignerOverrideFromWalletClientSigner } from '../../utils/intentUtils'
 import {
   BuildDeployAccountSigningPayloadArgs,
   buildDeployAccountSigningPayload,
@@ -84,12 +85,22 @@ export class CollateralAccountModule {
           const address = args.address ?? this.defaultAddress
           throwIfZeroAddress(address)
 
+          args.overrides = addSignerOverrideFromWalletClientSigner({
+            walletClientSigner: this.config.walletClient?.account?.address,
+            overrides: args.overrides,
+          })
+
           return buildDeployAccountSigningPayload({ chainId: this.config.chainId, ...args, address })
         },
 
         withdrawal: (args: OmitBound<BuildWithdrawalSigningPayloadArgs> & OptionalAddress) => {
           const address = args.address ?? this.defaultAddress
           throwIfZeroAddress(address)
+
+          args.overrides = addSignerOverrideFromWalletClientSigner({
+            walletClientSigner: this.config.walletClient?.account?.address,
+            overrides: args.overrides,
+          })
 
           return buildWithdrawalSigningPayload({ chainId: this.config.chainId, ...args, address })
         },
@@ -98,12 +109,22 @@ export class CollateralAccountModule {
           const address = args.address ?? this.defaultAddress
           throwIfZeroAddress(address)
 
+          args.overrides = addSignerOverrideFromWalletClientSigner({
+            walletClientSigner: this.config.walletClient?.account?.address,
+            overrides: args.overrides,
+          })
+
           return buildMarketTransferSigningPayload({ chainId: this.config.chainId, ...args, address })
         },
 
         rebalanceConfigChange: (args: OmitBound<BuildRebalanceConfigChangeSigningPayloadArgs> & OptionalAddress) => {
           const address = args.address ?? this.defaultAddress
           throwIfZeroAddress(address)
+
+          args.overrides = addSignerOverrideFromWalletClientSigner({
+            walletClientSigner: this.config.walletClient?.account?.address,
+            overrides: args.overrides,
+          })
 
           return buildRebalanceConfigChangeSigningPayload({ chainId: this.config.chainId, ...args, address })
         },
@@ -112,12 +133,22 @@ export class CollateralAccountModule {
           const address = args.address ?? this.defaultAddress
           throwIfZeroAddress(address)
 
+          args.overrides = addSignerOverrideFromWalletClientSigner({
+            walletClientSigner: this.config.walletClient?.account?.address,
+            overrides: args.overrides,
+          })
+
           return buildRelayedSignerUpdateSigningPayload({ chainId: this.config.chainId, ...args, address })
         },
 
         relayedOperatorUpdate: (args: OmitBound<BuildRelayedOperatorUpdateSigningPayloadArgs> & OptionalAddress) => {
           const address = args.address ?? this.defaultAddress
           throwIfZeroAddress(address)
+
+          args.overrides = addSignerOverrideFromWalletClientSigner({
+            walletClientSigner: this.config.walletClient?.account?.address,
+            overrides: args.overrides,
+          })
 
           return buildRelayedOperatorUpdateSigningPayload({ chainId: this.config.chainId, ...args, address })
         },
@@ -128,6 +159,11 @@ export class CollateralAccountModule {
           const address = args.address ?? this.defaultAddress
           throwIfZeroAddress(address)
 
+          args.overrides = addSignerOverrideFromWalletClientSigner({
+            walletClientSigner: this.config.walletClient?.account?.address,
+            overrides: args.overrides,
+          })
+
           return buildRelayedAccessUpdateBatchSigningPayload({ chainId: this.config.chainId, ...args, address })
         },
 
@@ -137,6 +173,11 @@ export class CollateralAccountModule {
           const address = args.address ?? this.defaultAddress
           throwIfZeroAddress(address)
 
+          args.overrides = addSignerOverrideFromWalletClientSigner({
+            walletClientSigner: this.config.walletClient?.account?.address,
+            overrides: args.overrides,
+          })
+
           return buildRelayedGroupCancellationSigningPayload({ chainId: this.config.chainId, ...args, address })
         },
 
@@ -145,6 +186,11 @@ export class CollateralAccountModule {
         ) => {
           const address = args.address ?? this.defaultAddress
           throwIfZeroAddress(address)
+
+          args.overrides = addSignerOverrideFromWalletClientSigner({
+            walletClientSigner: this.config.walletClient?.account?.address,
+            overrides: args.overrides,
+          })
 
           return buildRelayedNonceCancellationSigningPayload({ chainId: this.config.chainId, ...args, address })
         },

--- a/src/lib/markets/index.ts
+++ b/src/lib/markets/index.ts
@@ -15,6 +15,7 @@ import {
 import { OptionalAddress } from '../../types/shared'
 import { notEmpty } from '../../utils'
 import { throwIfZeroAddress } from '../../utils/addressUtils'
+import { addSignerOverrideFromWalletClientSigner } from '../../utils/intentUtils'
 import { mergeMultiInvokerTxs } from '../../utils/multiinvoker'
 import { waitForOrderSettlement } from '../../utils/positionUtils'
 import { OracleClients } from '../oracle'
@@ -720,6 +721,11 @@ export class MarketsModule {
           const address = args.address ?? this.defaultAddress
           throwIfZeroAddress(address)
 
+          args.overrides = addSignerOverrideFromWalletClientSigner({
+            walletClientSigner: this.config.walletClient?.account?.address,
+            overrides: args.overrides,
+          })
+
           return buildIntentSigningPayload({ chainId: this.config.chainId, ...args, address })
         },
 
@@ -727,12 +733,22 @@ export class MarketsModule {
           const address = args.address ?? this.defaultAddress
           throwIfZeroAddress(address)
 
+          args.overrides = addSignerOverrideFromWalletClientSigner({
+            walletClientSigner: this.config.walletClient?.account?.address,
+            overrides: args.overrides,
+          })
+
           return buildPlaceOrderSigningPayload({ chainId: this.config.chainId, ...args, address })
         },
 
         cancelOrder: (args: OmitBound<BuildCancelOrderSigningPayloadArgs> & OptionalAddress) => {
           const address = args.address ?? this.defaultAddress
           throwIfZeroAddress(address)
+
+          args.overrides = addSignerOverrideFromWalletClientSigner({
+            walletClientSigner: this.config.walletClient?.account?.address,
+            overrides: args.overrides,
+          })
 
           return buildCancelOrderSigningPayload({ chainId: this.config.chainId, ...args, address })
         },

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -21,3 +21,6 @@ export * as accumulatorUtils from './accumulatorUtils'
 
 export * from './fundingAndInterestUtils'
 export * as fundingAndInterestUtils from './fundingAndInterestUtils'
+
+export * from './intentUtils'
+export * as intentUtils from './intentUtils'

--- a/src/utils/intentUtils.ts
+++ b/src/utils/intentUtils.ts
@@ -1,3 +1,22 @@
+import { Address } from 'viem'
+
+import { CommonOverrides } from '../types/shared'
+
 export function generateNonce() {
   return BigInt(Date.now())
+}
+
+/**
+ * Adds a signer override to the overrides object if the signer is not already set.
+ * @param walletClientSigner - The address of the wallet client signer.
+ * @param overrides - The {@link CommonOverrides} object.
+ * @returns The updated overrides object.
+ */
+export function addSignerOverrideFromWalletClientSigner({
+  walletClientSigner,
+  overrides,
+}: {
+  walletClientSigner?: Address
+} & CommonOverrides) {
+  return Boolean(overrides?.signer) ? overrides : { ...overrides, signer: walletClientSigner }
 }


### PR DESCRIPTION
Adds a signer override to signing arguments if the `override.signer` is not already set and the wallet client address is present. This makes it easier to setup the SDK with a `walletClient` that is different than the `operatingFor` and have things work as expected