### PR TITLE
Add Manager trigger orders

### DIFF
--- a/src/graphQueries/markets.ts
+++ b/src/graphQueries/markets.ts
@@ -100,13 +100,13 @@ export const QueryMarketAccumulationData = gql(`
   }
 `)
 
-export const QueryMultiInvokerOpenOrders = gql(`
-  query QueryMultiInvokerOpenOrders($account: Bytes!, $markets: [Bytes!]!, $side: [Int!]!, $first: Int!, $skip: Int!) {
+export const QueryOpenTriggerOrders = gql(`
+  query QueryOpenTriggerOrders($account: Bytes!, $markets: [Bytes!]!, $side: [Int!]!, $first: Int!, $skip: Int!) {
     multiInvokerTriggerOrders(
       where: { account: $account, market_in: $markets, cancelled: false, executed: false, triggerOrderSide_in: $side },
       orderBy: nonce, orderDirection: desc, first: $first, skip: $skip
     ) {
-        account, market, nonce, triggerOrderSide, triggerOrderComparison, triggerOrderFee, triggerOrderPrice, triggerOrderDelta
+        source, account, market, nonce, triggerOrderSide, triggerOrderComparison, triggerOrderFee, triggerOrderPrice, triggerOrderDelta
         blockTimestamp, transactionHash, associatedOrder { collateral, depositTotal, withdrawalTotal }
       }
   }

--- a/src/lib/markets/graph.ts
+++ b/src/lib/markets/graph.ts
@@ -693,6 +693,8 @@ export async function fetchOpenOrders({
     ...triggerOrder,
     market: addressToMarket(chainId, triggerOrder.market),
     marketAddress: getAddress(triggerOrder.market),
+    source: getAddress(triggerOrder.source),
+    account: getAddress(triggerOrder.account),
   }))
 }
 


### PR DESCRIPTION
Adds Manager trigger orders to the graph query. The difference between manager and multiInvoker trigger orders is the `source` and the `side`. When sending cancellation transactions we'll need to look at the order source to know where to send it.