### PR TITLE
Fix nonce generation, return oracle version

### DIFF
--- a/examples/intents/marketCollateralTransfer.ts
+++ b/examples/intents/marketCollateralTransfer.ts
@@ -1,0 +1,49 @@
+import { addHours } from 'date-fns'
+import { config as dotenvConfig } from 'dotenv'
+import path from 'path'
+import { Hex, createWalletClient, http } from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+import { arbitrumSepolia } from 'viem/chains'
+
+import Perennial, { Big6Math, SupportedMarket, timeToSeconds } from '../../'
+
+dotenvConfig({ path: path.resolve(__dirname, '../../.env.local') })
+;(BigInt.prototype as any).toJSON = function () {
+  return this.toString()
+}
+
+async function run() {
+  const walletClient = createWalletClient({
+    account: privateKeyToAccount(process.env.PRIVATE_KEY! as Hex),
+    chain: arbitrumSepolia,
+    transport: http(process.env.RPC_URL_ARBITRUM_SEPOLIA!),
+  })
+  const address = walletClient.account.address
+
+  const sdk = new Perennial({
+    chainId: arbitrumSepolia.id,
+    rpcUrl: process.env.RPC_URL_ARBITRUM_SEPOLIA!,
+    graphUrl: process.env.GRAPH_URL_ARBITRUM!,
+    pythUrl: process.env.PYTH_URL!,
+    cryptexUrl: process.env.CRYPTEX_URL!,
+    operatingFor: address,
+    walletClient,
+  })
+
+  const controller = sdk.contracts.getControllerContract()
+  const { signature, marketTransfer } = await sdk.collateralAccounts.sign.marketTransfer({
+    market: SupportedMarket.eth,
+    amount: Big6Math.fromFloatString('-0.001'),
+    maxFee: Big6Math.fromFloatString('1'),
+    expiry: timeToSeconds(addHours(new Date(), 1), true),
+  })
+
+  // The account sending the transaction can be different from the one that the collateral account is deployed for
+  const { request } = await controller.simulate.marketTransferWithSignature([marketTransfer.message, signature], {
+    account: walletClient.account,
+  })
+  const txHash = await walletClient.writeContract(request)
+  console.log('Transaction sent:', txHash)
+}
+
+run()

--- a/scripts/genErrorAbi.ts
+++ b/scripts/genErrorAbi.ts
@@ -6,12 +6,14 @@ const allAbis = fs.readdirSync(path.join(__dirname, '../src/abi'))
 
 const allErrors: any[] = []
 allAbis.forEach((abi) => {
+  if (abi === 'AllErrors.abi.ts') return
   const abiPath = path.join(__dirname, `../src/abi/${abi}`)
   const abiRaw = require(abiPath)
 
   const errors = Object.values(abiRaw)
     .flat()
     .filter((item: any) => item.type === 'error')
+    .filter((item: any) => !allErrors.find((err) => err.name === item.name))
   allErrors.push(...errors)
 })
 

--- a/src/lib/markets/index.ts
+++ b/src/lib/markets/index.ts
@@ -356,7 +356,13 @@ export class MarketsModule {
        * @param txHash Transaction hash
        * @param onSettlement Optional callback to invoke on settlement
        */
-      waitForOrderSettlement: async (txHash: Hash, onSettlement?: (txReceipt?: TransactionReceipt) => void) => {
+      waitForOrderSettlement: async (
+        txHash: Hash,
+        onSettlement?: (res: {
+          txReceipt?: TransactionReceipt
+          version?: { timestamp: bigint; valid: boolean; price: bigint }
+        }) => void,
+      ) => {
         return waitForOrderSettlement({
           publicClient: this.config.publicClient,
           txHash,

--- a/src/utils/intentUtils.ts
+++ b/src/utils/intentUtils.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'crypto'
 import {
   Address,
   Hex,
@@ -20,8 +21,8 @@ import { CommonOverrides } from '../types/shared'
 import { addressForMarket } from './addressUtils'
 import { buildUpdateMarket, encodeInvoke, mergeMultiInvokerTxs } from './multiinvoker'
 
-export function generateNonce() {
-  return BigInt(Date.now())
+export function generateNonce(bytes = 32) {
+  return BigInt(`0x${randomBytes(bytes).toString('hex')}`)
 }
 
 /**

--- a/src/utils/positionUtils.ts
+++ b/src/utils/positionUtils.ts
@@ -643,7 +643,10 @@ export async function waitForOrderSettlement({
   publicClient: PublicClient
   txHash: Hash
   timeoutMs: number
-  onSettlement?: (txReceipt?: TransactionReceipt) => void
+  onSettlement?: (res: {
+    txReceipt?: TransactionReceipt
+    version?: { timestamp: bigint; valid: boolean; price: bigint }
+  }) => void
 }): Promise<TransactionReceipt> {
   return new Promise(async (resolve, reject) => {
     let timeoutId: NodeJS.Timeout
@@ -673,7 +676,7 @@ export async function waitForOrderSettlement({
         onLogs: (logs) => {
           const versionFulfilledEvent = logs.at(0)
           if (versionFulfilledEvent?.args?.version?.timestamp === version) {
-            onSettlement?.(receipt)
+            onSettlement?.({ txReceipt: receipt, version: versionFulfilledEvent?.args?.version })
             cleanup()
             resolve(receipt)
           }


### PR DESCRIPTION
Updates the `generateNonce` function to generate a random value from the provided byte size (defaults to 32 bytes which would translate to a uint256). Also updates the `waitForOrderSettlement` to return the oracle version of fulfillment so the caller can see the price or validity.