### PR TITLE
Add option to only compact digits and not the notation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perennial/sdk",
-  "version": "0.0.4-alpha.11",
+  "version": "0.0.4-alpha.12",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/utils/big18Utils.ts
+++ b/src/utils/big18Utils.ts
@@ -29,8 +29,8 @@ export const formatBig18USDPrice = (
   {
     compact = false,
     fromUsdc = false,
-    fractionDigits = 2,
-    significantDigits = 6,
+    fractionDigits,
+    significantDigits,
   }: { compact?: boolean; fromUsdc?: boolean; fractionDigits?: number; significantDigits?: number } = {},
 ) => {
   if (value === 0n) {
@@ -41,10 +41,10 @@ export const formatBig18USDPrice = (
     style: 'currency',
     currency: 'USD',
     notation: compact ? 'compact' : undefined,
-    minimumFractionDigits: compact ? 1 : fractionDigits,
-    maximumFractionDigits: compact ? 1 : fractionDigits,
-    minimumSignificantDigits: compact ? 2 : significantDigits,
-    maximumSignificantDigits: compact ? 2 : significantDigits,
+    minimumFractionDigits: fractionDigits ?? (compact ? 1 : 2),
+    maximumFractionDigits: fractionDigits ?? (compact ? 1 : 2),
+    minimumSignificantDigits: significantDigits ?? (compact ? 2 : 6),
+    maximumSignificantDigits: significantDigits ?? (compact ? 2 : 6),
     // @ts-ignore
     roundingPriority: 'morePrecision',
   }).format(valueToFormat)

--- a/src/utils/big18Utils.ts
+++ b/src/utils/big18Utils.ts
@@ -26,7 +26,12 @@ export const formatBig18 = (
 // Formats an 18 decimal bigint as a USD price
 export const formatBig18USDPrice = (
   value: bigint = 0n,
-  { compact = false, fromUsdc = false }: { compact?: boolean; fromUsdc?: boolean } = {},
+  {
+    compact = false,
+    fromUsdc = false,
+    fractionDigits = 2,
+    significantDigits = 6,
+  }: { compact?: boolean; fromUsdc?: boolean; fractionDigits?: number; significantDigits?: number } = {},
 ) => {
   if (value === 0n) {
     return '$0.00'
@@ -36,10 +41,10 @@ export const formatBig18USDPrice = (
     style: 'currency',
     currency: 'USD',
     notation: compact ? 'compact' : undefined,
-    minimumFractionDigits: compact ? 1 : 2,
-    maximumFractionDigits: compact ? 1 : 2,
-    minimumSignificantDigits: compact ? 2 : 6,
-    maximumSignificantDigits: compact ? 2 : 6,
+    minimumFractionDigits: compact ? 1 : fractionDigits,
+    maximumFractionDigits: compact ? 1 : fractionDigits,
+    minimumSignificantDigits: compact ? 2 : significantDigits,
+    maximumSignificantDigits: compact ? 2 : significantDigits,
     // @ts-ignore
     roundingPriority: 'morePrecision',
   }).format(valueToFormat)

--- a/src/utils/big6Utils.ts
+++ b/src/utils/big6Utils.ts
@@ -40,10 +40,17 @@ export const formatBig6USDPrice = (
   value: bigint = 0n,
   {
     compact = false,
-    compactDigits = false,
     fromUsdc = false,
     fullPrecision = false,
-  }: { compact?: boolean; compactDigits?: boolean; fromUsdc?: boolean; fullPrecision?: boolean } = {},
+    fractionDigits = 2,
+    significantDigits = 6,
+  }: {
+    compact?: boolean
+    significantDigits?: number
+    fractionDigits?: number
+    fromUsdc?: boolean
+    fullPrecision?: boolean
+  } = {},
 ) => {
   // Hardcoding this to return $0.00 because 'roundingPriority' option is not supported in node 18
   // resulting in a hydration error when the resolution occurs on first client render
@@ -51,17 +58,15 @@ export const formatBig6USDPrice = (
     return '$0.00'
   }
 
-  compactDigits = compact
-
   const valueToFormat = fromUsdc ? Number(formatUnits(value, 6)) : Big6Math.toUnsafeFloat(value)
   return Intl.NumberFormat('en-US', {
     style: 'currency',
     currency: 'USD',
     notation: compact ? 'compact' : undefined,
-    minimumFractionDigits: 2,
-    maximumFractionDigits: fullPrecision ? 6 : 2,
-    minimumSignificantDigits: compactDigits ? 2 : 6,
-    maximumSignificantDigits: compactDigits ? 2 : 6,
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fullPrecision ? 6 : fractionDigits,
+    minimumSignificantDigits: compact ? 2 : significantDigits,
+    maximumSignificantDigits: compact ? 2 : significantDigits,
     // @ts-ignore
     roundingPriority: 'morePrecision',
   }).format(valueToFormat)

--- a/src/utils/big6Utils.ts
+++ b/src/utils/big6Utils.ts
@@ -40,15 +40,19 @@ export const formatBig6USDPrice = (
   value: bigint = 0n,
   {
     compact = false,
+    compactDigits = false,
     fromUsdc = false,
     fullPrecision = false,
-  }: { compact?: boolean; fromUsdc?: boolean; fullPrecision?: boolean } = {},
+  }: { compact?: boolean; compactDigits?: boolean; fromUsdc?: boolean; fullPrecision?: boolean } = {},
 ) => {
   // Hardcoding this to return $0.00 because 'roundingPriority' option is not supported in node 18
   // resulting in a hydration error when the resolution occurs on first client render
   if (value === 0n) {
     return '$0.00'
   }
+
+  compactDigits = compact
+
   const valueToFormat = fromUsdc ? Number(formatUnits(value, 6)) : Big6Math.toUnsafeFloat(value)
   return Intl.NumberFormat('en-US', {
     style: 'currency',
@@ -56,8 +60,8 @@ export const formatBig6USDPrice = (
     notation: compact ? 'compact' : undefined,
     minimumFractionDigits: 2,
     maximumFractionDigits: fullPrecision ? 6 : 2,
-    minimumSignificantDigits: compact ? 2 : 6,
-    maximumSignificantDigits: compact ? 2 : 6,
+    minimumSignificantDigits: compactDigits ? 2 : 6,
+    maximumSignificantDigits: compactDigits ? 2 : 6,
     // @ts-ignore
     roundingPriority: 'morePrecision',
   }).format(valueToFormat)

--- a/src/utils/big6Utils.ts
+++ b/src/utils/big6Utils.ts
@@ -42,8 +42,8 @@ export const formatBig6USDPrice = (
     compact = false,
     fromUsdc = false,
     fullPrecision = false,
-    fractionDigits = 2,
-    significantDigits = 6,
+    fractionDigits,
+    significantDigits,
   }: {
     compact?: boolean
     significantDigits?: number
@@ -63,10 +63,10 @@ export const formatBig6USDPrice = (
     style: 'currency',
     currency: 'USD',
     notation: compact ? 'compact' : undefined,
-    minimumFractionDigits: fractionDigits,
-    maximumFractionDigits: fullPrecision ? 6 : fractionDigits,
-    minimumSignificantDigits: compact ? 2 : significantDigits,
-    maximumSignificantDigits: compact ? 2 : significantDigits,
+    minimumFractionDigits: fractionDigits ?? 2,
+    maximumFractionDigits: fractionDigits ?? (fullPrecision ? 6 : 2),
+    minimumSignificantDigits: significantDigits ?? (compact ? 2 : 6),
+    maximumSignificantDigits: significantDigits ?? (compact ? 2 : 6),
     // @ts-ignore
     roundingPriority: 'morePrecision',
   }).format(valueToFormat)

--- a/src/utils/big6Utils.ts
+++ b/src/utils/big6Utils.ts
@@ -46,10 +46,10 @@ export const formatBig6USDPrice = (
     significantDigits,
   }: {
     compact?: boolean
-    significantDigits?: number
-    fractionDigits?: number
     fromUsdc?: boolean
     fullPrecision?: boolean
+    significantDigits?: number
+    fractionDigits?: number
   } = {},
 ) => {
   // Hardcoding this to return $0.00 because 'roundingPriority' option is not supported in node 18


### PR DESCRIPTION
There is no easy way to format big6Prices in the frontend to 2 decimals. There is a couple of ways to do this and am happy with any so its up to you on what you think is the best api and aligns with the current setup

- extra flag to only compact digits, is set to true if `compact` is passed in (this way)
- direct controls of min / max digits (more control but less opinionated)
- optional arbitrary args to `Intl.NumberFormat` function (most arbitrary control) 
- override the `notation` value set